### PR TITLE
Enable deployment to GCS for staging/beta/stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,170 @@
-version: 2
+version: 2.1
 
 jobs:
-  build_and_test:
+  preconditions:
     docker: &BUILDIMAGE
       - image: jenkinsrise/cci-v2-components:0.0.4
     steps:
+      - run: |
+          if [ -z "$COMPONENT_NAME" ]
+          then
+            echo Component name must be specified as an environment variable.
+            exit 1
+          fi
+
+  install:
+    docker: *BUILDIMAGE
+    steps:
       - checkout
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
       - run: npm install
+      - save_cache:
+          key: node-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+
+  test:
+    docker: *BUILDIMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
       - run: npm test
 
+  build:
+    docker: *BUILDIMAGE
+    steps:
+      - checkout
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
+  gcloud-setup:
+    docker: &GCSIMAGE
+      - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
+    steps:
+      - run: mkdir -p ~/.ssh
+      - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: git clone git@github.com:Rise-Vision/private-keys.git
+      - run: mv private-keys ..
+      - run: gcloud auth activate-service-account 452091732215@developer.gserviceaccount.com --key-file ../private-keys/storage-server/rva-media-library-ce0d2bd78b54.json
+      - persist_to_workspace:
+          root: ~/.config
+          paths:
+            - gcloud
+
+  generate-version:
+    docker: *BUILDIMAGE
+    steps:
+      - run: mkdir version-string
+      - run: echo $(date +%Y.%m.%d.%H.%M) > version-string/version
+      - persist_to_workspace:
+          root: .
+          paths:
+            - version-string
+
+  deploy-stage:
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: npm install common-component
+      - run: |
+          GS_BASE=gs://widgets.risevision.com
+          VERSION=$(cat version-string/version)
+          TARGET=$GS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
+          echo Deploying version $VERSION to $COMPONENT_NAME
+          node_modules/common-component/deploy_gcs.sh $COMPONENT_NAME $TARGET
+
+  deploy-production:
+    parameters:
+      stage:
+        type: string
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: npm install common-component
+      - run: |
+          GS_BASE=gs://widgets.risevision.com
+          TARGET=$GS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
+          echo Deploying << parameters.stage >> version of $COMPONENT_NAME
+          node_modules/common-component/deploy_gcs.sh $COMPONENT_NAME $TARGET
+
 workflows:
-  version: 2
   workflow1:
     jobs:
-      - build_and_test
+      - preconditions
+      - install:
+          requires:
+            - preconditions
+      - gcloud-setup:
+          requires:
+            - preconditions
+          filters:
+            branches:
+              only:
+                - /^(stage|staging)[/].*/
+                - master
+                - build/stable
+      - generate-version:
+          requires:
+            - preconditions
+          filters:
+            branches:
+              only:
+                - /^(stage|staging)[/].*/
+                - master
+                - build/stable
+      - test:
+          requires:
+            - install
+      - build:
+          requires:
+            - test
+      - deploy-stage:
+          requires:
+            - gcloud-setup
+            - generate-version
+            - build
+          filters:
+            branches:
+              only:
+                - /^(stage|staging)[/].*/
+                - master
+                - build/stable
+      - deploy-production:
+          stage: beta
+          requires:
+            - gcloud-setup
+            - generate-version
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - deploy-production:
+          stage: stable
+          requires:
+            - gcloud-setup
+            - generate-version
+            - build
+          filters:
+            branches:
+              only:
+                - build/stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           VERSION=$(cat version-string/version)
           TARGET=$GS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
-          node_modules/common-component/deploy_gcs.sh $COMPONENT_NAME $TARGET
+          node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
   deploy-production:
     parameters:
@@ -104,7 +104,7 @@ jobs:
           GS_BASE=gs://widgets.risevision.com
           TARGET=$GS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
           echo Deploying << parameters.stage >> version of $COMPONENT_NAME
-          node_modules/common-component/deploy_gcs.sh $COMPONENT_NAME $TARGET
+          node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
 workflows:
   workflow1:

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,6 +266,10 @@
         "graceful-readlink": ">= 1.0.0"
       }
     },
+    "common-component": {
+      "version": "git://github.com/Rise-Vision/common-component.git#b3eeaae9d743aca2d8a0126858e94660372552b9",
+      "from": "git://github.com/Rise-Vision/common-component.git#v1.16.1"
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
+    "build": "polymer build && ./node_modules/common-component/extract-source.sh rise-data-financial",
     "test": "eslint . && polymer test --npm"
   },
   "repository": {
@@ -23,6 +24,7 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-data-financial#readme",
   "dependencies": {
+    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.16.1",
     "@polymer/polymer": "^3.0.5",
     "@webcomponents/webcomponentsjs": "^2.1.3"
   },

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -1,6 +1,13 @@
 import { PolymerElement } from "@polymer/polymer/polymer-element.js";
 
 class RiseDataFinancial extends PolymerElement {
+
+  constructor() {
+    super();
+
+    // TODO: coming soon
+  }
+
 }
 
 customElements.define( "rise-data-financial", RiseDataFinancial );

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -5,7 +5,7 @@ class RiseDataFinancial extends PolymerElement {
   constructor() {
     super();
 
-    // TODO: coming soon
+    // TODO:
   }
 
 }


### PR DESCRIPTION
- Using common Polymer 3 component build/deploy scripts `extract-source.sh` and `deploy-gcs.sh` from common-component repo
- CCI config updated to implement same workflow as [rise-data-image](https://github.com/Rise-Vision/rise-data-image/blob/master/.circleci/config.yml) , enabling to deploy to GCS for staging, beta, and stable. 
- staging deployment validated - https://circleci.com/workflow-run/fa35ad07-b301-4358-8062-c8ffefb9d527