### PR TITLE
Configure WCT for Chrome only and support HTML and JS test suites

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   "env": {
     "browser": true,
-    "es6": true
+    "es6": true,
+    "node": true
   },
   "extends": [
     "eslint:recommended",

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>Tests</title>
+
+  <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+  <!-- load any .js for non html (i.e. library) unit tests -->
+</head>
+<body>
+<script>
+  /* global WCT */
+  WCT.loadSuites( [
+    "unit/rise-data-financial-test.html"
+  ] );
+</script>
+</body>
+</html>

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -1,0 +1,9 @@
+module.exports = {
+  verbose: true,
+  plugins: {
+    local: {
+      browsers: [ "chrome" ]
+    }
+  },
+  wctPackageName: "wct-browser-legacy"
+};


### PR DESCRIPTION
- Include wct config file to specify Chrome browser as only browser to test against. CCI is inconsistent with running against Firefox, and Safari always fails locally. Given we only ship our Players currently with Chrome browser, it can suffice. 
- Support nested suites with a `index.html` that can load `.js` and `.html` files to allow for suite testing separate code from the component source, i.e. a library. 