### PR TITLE
Add remaining attributes and prep data request

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,8 @@ module.exports = {
       "error",
       "always"
     ]
+  },
+  "globals": {
+    "RisePlayerConfiguration": false
   }
 };

--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,8 @@
   /* global WCT */
   WCT.loadSuites( [
     "integration/rise-data-financial-realtime.html",
-    "unit/rise-data-financial.html"
+    "unit/rise-data-financial.html",
+    "unit/rise-data-financial-historical.html"
   ] );
 </script>
 </body>

--- a/test/mocks/firebase.js
+++ b/test/mocks/firebase.js
@@ -45,6 +45,13 @@ let _firebaseConnectionStatus = true,
                     }
                   }
                 });
+              },
+              off: ( key ) => {
+                if ( key !== "value" ) {
+                  return;
+                }
+
+                fireConnStatusCallback = undefined;
               }
             };
           }

--- a/test/unit/rise-data-financial-historical.html
+++ b/test/unit/rise-data-financial-historical.html
@@ -22,20 +22,23 @@
 </test-fixture>
 
 <script>
-  suite("rise-data-financial", () => {
+  suite("rise-data-financial - Historical", () => {
 
     let element,
-      clock;
+      clock,
+      financialResetStub;
 
     setup(() => {
       RisePlayerConfiguration.getDisplayId = () => {
         return "ABC123";
       };
 
-      element = fixture("test-block")
+      element = fixture("test-block");
+      financialResetStub = sinon.stub(element, "_financialReset");
     });
 
     teardown(() => {
+      financialResetStub.restore();
       RisePlayerConfiguration.getDisplayId = {};
     });
 
@@ -47,15 +50,18 @@
       clock.restore();
     } );
 
+    suite( "_isValidDuration", () => {
 
-    suite( "financial list id change", () => {
+      test( "should return true if retrieving historical data for a valid duration", () => {
+        assert.isTrue( element._isValidDuration( "Week", "historical" ) );
+      } );
 
-      test( "should call _financialReset()", () => {
-        let changedStub = sinon.stub( element, "_financialReset" );
+      test( "should return false if retrieving historical data for an invalid duration", () => {
+        assert.isFalse( element._isValidDuration( "week", "historical" ) );
+      } );
 
-        element.setAttribute( "financial-list", "abc123" );
-        assert.isTrue( changedStub.calledOnce );
-        changedStub.restore();
+      test( "should return true if not retrieving historical data", () => {
+        assert.isTrue( element._isValidDuration( "week", "realtime" ) );
       } );
 
     } );

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -167,12 +167,12 @@
         }, 500);
       } );
 
-      test( "should fire 'rise-financial-no-data' if firebase not connected and localStorage empty", ( done ) => {
+      test( "should send 'instruments-unavailable' event if firebase not connected and localStorage empty", ( done ) => {
         let listener = () => {
           element._getInstrumentsFromLocalStorage.restore();
           element._firebaseConnected = true;
           element._instrumentsReceived = true;
-          element.removeEventListener( "rise-financial-no-data", listener );
+          element.removeEventListener( "instruments-unavailable", listener );
           done();
         };
 
@@ -183,7 +183,7 @@
         element._instrumentsReceived = false;
         element._firebaseConnected = false;
 
-        element.addEventListener( "rise-financial-no-data", listener );
+        element.addEventListener( "instruments-unavailable", listener );
         element._getInstruments();
       } );
 
@@ -209,24 +209,41 @@
 
     suite( "_handleInstruments", () => {
 
-      test( "should set _instruments", () => {
+      test( "should set _instruments and send 'instruments-received' event", ( done ) => {
+        let listener = () => {
+          element.removeEventListener( "instruments-received", listener );
+
+          assert.deepEqual( element._instruments, [ inst1 ] );
+
+          done();
+        };
+
+        element.addEventListener( "instruments-received", listener );
+
         element._handleInstruments( {
           val: () => {
             return instrument;
           }
         } );
-
-        assert.deepEqual( element._instruments, [ inst1 ] );
       } );
 
-      test( "should not set _instruments", () => {
+      test( "should set _instruments to empty array and send 'instruments-received' event", ( done ) => {
+        let listener = () => {
+          element.removeEventListener( "instruments-received", listener );
+
+          assert.deepEqual( element._instruments, [] );
+
+          done();
+        };
+
+        element.addEventListener( "instruments-received", listener );
+
         element._handleInstruments( {
           val: () => {
             return null;
           }
         } );
 
-        assert.deepEqual( element._instruments, [] );
       } );
 
     } );
@@ -322,40 +339,34 @@
       } );
     } );
 
-    suite( "go", () => {
+    suite( "_handleStart", () => {
 
       teardown( () => {
-        element._goPending = false;
-        element._initialGo = true;
+        element._initialStart = true;
       } );
 
-      test( "should flag that a go() is pending if instruments have not been received", () => {
-        element._instrumentsReceived = false;
-        element.go();
-
-        assert.isTrue( element._goPending );
-      } );
-
-      test( "should call _getData() when this is the initial go() call", () => {
+      test( "should call _getData() when this is the initial 'start'", () => {
         const spy = sinon.stub( element, "_getData" );
 
         element._instrumentsReceived = true;
-        element.go();
 
-        assert.isFalse( element._goPending, "_goPending set to false" );
+        const event = new CustomEvent( "start" );
+        element.dispatchEvent( event );
+
         assert.isTrue( spy.calledOnce, "_getData is called" );
-        assert.isFalse( element._initialGo, "_initialGo set to false" );
+        assert.isFalse( element._initialStart, "_initialStart set to false" );
 
         spy.restore();
       } );
 
-      test( "should not call _getData() when this is not initial go", () => {
+      test( "should not call _getData() when this is not the initial start", () => {
         const spy = sinon.stub( element, "_getData" );
 
         element._instrumentsReceived = true;
-        element._initialGo = false;
+        element._initialStart = false;
 
-        element.go();
+        const event = new CustomEvent( "getData" );
+        element.dispatchEvent( event );
 
         assert.equal( spy.callCount, 0, "_getData is not called" );
 

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -8,6 +8,9 @@
   <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script src="../mocks/firebase.js"></script>
+  <script type="text/javascript">
+    RisePlayerConfiguration = {};
+  </script>
   <script src="../../src/rise-data-financial-config.js" type="module"></script>
   <script src="../../src/rise-data-financial.js" type="module"></script>
 </head>
@@ -47,11 +50,19 @@
       financialResetStub;
 
     setup(() => {
+      RisePlayerConfiguration.getDisplayId = () => {
+        return "ABC123";
+      };
+
       element = fixture("test-block");
       financialResetStub = sinon.stub(element, "_financialReset");
+
     });
 
-    teardown(() => financialResetStub.restore());
+    teardown(() => {
+      financialResetStub.restore();
+      RisePlayerConfiguration.getDisplayId = {};
+    });
 
     suiteSetup( () => {
       clock = sinon.useFakeTimers();
@@ -69,6 +80,22 @@
 
       test( "should set instrument fields array", () => {
         assert.deepEqual( element.instrumentFields, [ "lastPrice", "netChange" ] );
+      } );
+
+    } );
+
+    suite( "_isValidType", () => {
+
+      test( "should return true if 'type' attribute is 'realtime'", () => {
+        assert.isTrue( element._isValidType( "realtime" ) );
+      } );
+
+      test( "should return true if 'type' attribute is 'historical'", () => {
+        assert.isTrue( element._isValidType( "historical" ) );
+      } );
+
+      test( "should return false when invalid", () => {
+        assert.isFalse( element._isValidType( "test" ) );
       } );
 
     } );
@@ -254,7 +281,8 @@
       } );
 
       teardown( () => {
-        element._getInstruments.restore();
+        stub.restore();
+        setFirebaseConnectionStatus( true );
       } );
 
       test( "should set firebase connected status and call '_getInstruments()' when still needing instruments", () => {
@@ -284,6 +312,54 @@
         assert.isFalse( element._firebaseConnected );
 
         element._firebaseConnected = true;
+      } );
+
+    } );
+
+    suite( "ready", () => {
+      test( "should set display id when a valid display id is provided", () => {
+        assert.equal( element.displayId, "ABC123" );
+      } );
+    } );
+
+    suite( "go", () => {
+
+      teardown( () => {
+        element._goPending = false;
+        element._initialGo = true;
+      } );
+
+      test( "should flag that a go() is pending if instruments have not been received", () => {
+        element._instrumentsReceived = false;
+        element.go();
+
+        assert.isTrue( element._goPending );
+      } );
+
+      test( "should call _getData() when this is the initial go() call", () => {
+        const spy = sinon.stub( element, "_getData" );
+
+        element._instrumentsReceived = true;
+        element.go();
+
+        assert.isFalse( element._goPending, "_goPending set to false" );
+        assert.isTrue( spy.calledOnce, "_getData is called" );
+        assert.isFalse( element._initialGo, "_initialGo set to false" );
+
+        spy.restore();
+      } );
+
+      test( "should not call _getData() when this is not initial go", () => {
+        const spy = sinon.stub( element, "_getData" );
+
+        element._instrumentsReceived = true;
+        element._initialGo = false;
+
+        element.go();
+
+        assert.equal( spy.callCount, 0, "_getData is not called" );
+
+        spy.restore();
       } );
 
     } );


### PR DESCRIPTION
- Added remaining `type`, `duration`, and `symbol` attributes
- Setting read-only display id value via `RisePlayerConfiguration.getDisplayId()`
- Validating `type` and historical `duration` values
- Adding public `go()` function and conditional logic to ensure an initial request to get data will be executed
