### PR TITLE
Construct and make JSONP request via iron-jsonp-library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@polymer/iron-jsonp-library": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-jsonp-library/-/iron-jsonp-library-3.0.1.tgz",
+      "integrity": "sha512-JpIommURLt9DCqcaJaxsUiDWEaVWV2zoq12oJAMO65Do9Sl9TAv556bI7I4mLJcE40otPZ4wYap4kFViORMiKA==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/polymer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-data-financial#readme",
   "dependencies": {
-    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.16.1",
+    "@polymer/iron-jsonp-library": "^3.0.1",
     "@polymer/polymer": "^3.0.5",
-    "@webcomponents/webcomponentsjs": "^2.1.3"
+    "@webcomponents/webcomponentsjs": "^2.1.3",
+    "common-component": "git://github.com/Rise-Vision/common-component.git#v1.16.1"
   },
   "devDependencies": {
     "eslint": "^5.6.1",

--- a/test/unit/rise-data-financial-historical.html
+++ b/test/unit/rise-data-financial-historical.html
@@ -66,6 +66,89 @@
 
     } );
 
+    suite( "_getData", () => {
+
+      const instrument = [
+          {
+            category: "Stocks",
+            index: 0,
+            name: "Alcoa",
+            symbol: "AA.N",
+            $id: "AA?N",
+          },
+          {
+            category: "Stocks",
+            index: 1,
+            name: "APPLE INC.",
+            symbol: "AAAPL.O",
+            $id: "AAPL?O",
+          }
+        ],
+        props = {
+          type: "historical",
+          duration: "1M",
+        };
+
+      test( "should not execute if component configured with an invalid duration", () => {
+        const stub = sinon.stub( element, "_getSymbols" );
+
+        element._getData( { type: "historical", duration: "invalid" }, instrument, [] );
+
+        assert.isFalse( stub.called );
+
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with correct financial test server url", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        element._getData( props, instrument, [] );
+
+        assert.equal( stub.args[0][0], "https://contentfinancial2-test.appspot.com/data/historical" );
+
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with correct params", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        const expected = {
+          id: "ABC123",
+          code: "AA.N|AAAPL.O",
+          kind: "1M",
+        };
+
+        element._getData( props, instrument, [] );
+        assert.equal( stub.args[0][1].id, expected.id );
+        assert.equal( stub.args[0][1].code, expected.code );
+        assert.equal( stub.args[0][1].kind, expected.kind );
+        assert.include( stub.args[0][1].tqx, "out:json;responseHandler:" );
+
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with correct params with only one symbol when symbol attribute is set on the component", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        const expected = {
+          id: "ABC123",
+          code: "AAAPL.O",
+          kind: "1M",
+        };
+
+        element.setAttribute( "symbol", "AAAPL.O" );
+        element._getData( props, instrument, [] );
+
+        assert.equal( stub.args[0][1].id, expected.id );
+        assert.equal( stub.args[0][1].code, expected.code );
+        assert.equal( stub.args[0][1].kind, expected.kind );
+        assert.include( stub.args[0][1].tqx, "out:json;responseHandler:" );
+
+        stub.restore();
+      } );
+
+    } );
+
   });
 </script>
 

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -24,7 +24,8 @@
 <script>
   suite("rise-data-financial", () => {
 
-    const inst1 = {
+    const fields = [ "lastPrice", "netChange" ],
+      inst1 = {
         category: "Stocks",
         index: 0,
         name: "Alcoa",
@@ -263,6 +264,219 @@
 
         assert.deepEqual( JSON.parse( localStorage.getItem( `risedatafinancial_${element.financialList}` ) ),
           [ inst1 ] ); // eslint-disable-line quotes
+      } );
+
+    } );
+
+    suite( "_getParams", () => {
+
+      test( "should return query parameters object", () => {
+
+        const callback = ( btoa( "request" + element._getKey() ) ).substr( 0, 10 ) + Math.random(),
+          expected = {
+            id: "ABC123",
+            code: inst1.symbol,
+            tq: "select lastPrice,netChange",
+            tqx: "out:json;responseHandler:" + callback,
+          };
+
+        assert.deepEqual( element._getParams( fields, inst1.symbol, callback ), expected );
+      } );
+
+      test( "should return query parameters object with no 'tq' property", () => {
+        const callback = ( btoa( "request" + element._getKey() ) ).substr( 0, 10 ) + Math.random(),
+          expected = {
+            id: "ABC123",
+            code: inst1.symbol,
+            tqx: "out:json;responseHandler:" + callback,
+          };
+
+        assert.deepEqual( element._getParams( [], inst1.symbol, callback ), expected );
+      } );
+
+    } );
+
+    suite( "_getQueryString", () => {
+
+      test( "should return query string for fetching a specific set of fields", () => {
+        const expected = "select lastPrice,netChange";
+
+        assert.equal( element._getQueryString( fields ), expected );
+      } );
+
+      test( "should return empty string if no parameter specified", () => {
+        assert.equal( element._getQueryString( [] ), "" );
+      } );
+
+    } );
+
+    suite( "_getSymbols", () => {
+
+      teardown( () => {
+        element.setAttribute( "symbol", "" );
+        element._invalidSymbol = false;
+      } );
+
+      test( "should return empty string if no instruments", () => {
+        assert.equal( element._getSymbols( [] ), "" );
+      } );
+
+      test( "should return string of instrument symbols separated by |", () => {
+        assert.equal( element._getSymbols( instruments ), "AA.N|.DJI" );
+      } );
+
+      test( "should return only the single symbol if the symbol attribute is set and it is within the list of instruments", () => {
+        element.setAttribute( "symbol", ".DJI" );
+        assert.equal( element._getSymbols( instruments ), ".DJI" );
+      } );
+
+      test( "should set invalidSymbol and send 'invalid-symbol' event", ( done ) => {
+        let listener = () => {
+          element.removeEventListener( "invalid-symbol", listener );
+
+          assert.isTrue( element._invalidSymbol );
+
+          done();
+        };
+
+        element.addEventListener( "invalid-symbol", listener );
+
+        element.setAttribute( "symbol", ".TEST" );
+        assert.equal( element._getSymbols( instruments ), "" );
+      } );
+
+    } );
+
+    suite( "_getKey()", () => {
+
+      test( "should return correct key value when configured with defaults and without symbol", () => {
+        const expected = `risedatafinancial_${element.type}_${element.displayId}_${element.financialList}_${element.duration}_`;
+        assert.equal( element._getKey(), expected );
+      } );
+
+      test( "should return correct key value when configured different from defaults and with symbol", () => {
+        element.symbol = instrument.symbol;
+        element.type = "historical";
+        element.duration = "week";
+
+        const expected = `risedatafinancial_${element.type}_${element.displayId}_${element.financialList}_${element.duration}_${element.symbol}`;
+        assert.equal( element._getKey(), expected );
+      } );
+
+    });
+
+    suite( "_getSerializedUrl", () => {
+
+      test( "should return a serialized url with query params", () => {
+        const callback = element._getCallbackValue( element._getKey() ),
+          params = {
+            id: "ABC123",
+            code: inst1.symbol,
+            tq: "select lastPrice,netChange",
+            tqx: "out:json;responseHandler:" + callback,
+          },
+          expected = `https://contentfinancial2.appspot.com/data?id=ABC123&code=AA.N&tq=select%20lastPrice%2CnetChange&tqx=out%3Ajson%3BresponseHandler%3A${callback}`;
+
+        assert.equal( element._getSerializedUrl( "https://contentfinancial2.appspot.com/data", params ), expected );
+      } );
+
+    });
+
+    suite( "_getData", () => {
+
+      const props = {
+          type: "realtime",
+          duration: "1M",
+        };
+
+      test( "should not execute if component configured with an invalid type", () => {
+        const stub = sinon.stub( element, "_getSymbols" );
+
+        element._getData( { type: "invalid", duration: "1M" }, instruments, [] );
+
+        assert.isFalse( stub.called );
+
+        stub.restore();
+      } );
+
+      test( "should not execute if component configured for historical with an invalid duration", () => {
+        const stub = sinon.stub( element, "_getSymbols" );
+
+        element._getData( { type: "historical", duration: "invalid" }, instruments, [] );
+
+        assert.isFalse( stub.called );
+
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with realtime financial test server url", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        element._getData( props, instruments, [] );
+
+        assert.equal( stub.args[0][0], "https://contentfinancial2-test.appspot.com/data" );
+
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with historical financial test server url", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        props.type = "historical";
+        element._getData( props, instruments, [] );
+
+        assert.equal( stub.args[0][0], "https://contentfinancial2-test.appspot.com/data/historical" );
+
+        props.type = "realtime";
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with correct params for single instrument", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        const expected = {
+          id: "ABC123",
+          code: "AA.N",
+          tq: "select lastPrice,netChange"
+        };
+
+        element._getData( props, [ inst1 ], fields );
+        assert.equal( stub.args[0][1].id, expected.id );
+        assert.equal( stub.args[0][1].code, expected.code );
+        assert.equal( stub.args[0][1].tq, expected.tq );
+        assert.include( stub.args[0][1].tqx, "out:json;responseHandler:" );
+
+        stub.restore();
+      } );
+
+      test( "should call '_getSerializedUrl()' with correct params for multiple instruments", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        const expected = {
+          id: "ABC123",
+          code: "AA.N|.DJI",
+          tq: "select lastPrice,netChange"
+        };
+
+        element._getData( props, instruments, fields );
+
+        assert.equal( stub.args[0][1].id, expected.id );
+        assert.equal( stub.args[0][1].code, expected.code );
+        assert.equal( stub.args[0][1].tq, expected.tq );
+        assert.include( stub.args[0][1].tqx, "out:json;responseHandler:" );
+
+        stub.restore();
+      } );
+
+      test( "should not execute request if symbol is invalid", () => {
+        const stub = sinon.stub( element, "_getSerializedUrl" );
+
+        element.setAttribute( "symbol", ".YYY" );
+        element._getData( props, instruments, fields );
+
+        assert.isFalse( stub.called );
+
+        stub.restore();
       } );
 
     } );


### PR DESCRIPTION
- Using Polymers own [iron-jsonp-library](https://www.webcomponents.org/element/@polymer/iron-jsonp-library) to facilitate making the JSONP request
- Configured iron-jsonp-library and implemented constructing all required url and query params for making the request
- Temporarily having the component listen for _"override-displayid"_ event to set the displayid on the component for testing and marketwall purposes
- Handling the response data, error, and applying a refresh is to come in further PRs