### PR TITLE
Handle data update, data error, and a jsonp request error

### DIFF
--- a/test/data/realtime.js
+++ b/test/data/realtime.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-unused-vars */
+
+const realTimeData = {
+  sig: "1370849918",
+  status: "ok",
+  table: {
+    cols: [
+      { id: "lastPrice", label: "Last Price", pattern: "", type: "number" },
+      { id: "netChange", label: "Change", pattern: "", type: "number" },
+    ],
+    rows: [ {
+      c: [
+        { v: 12.3 },
+        { v: 12.3 },
+      ]
+    } ]
+  },
+  version: "0.6"
+};

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -21,6 +21,8 @@
   </template>
 </test-fixture>
 
+<script src="../data/realtime.js"></script>
+
 <script>
   suite("rise-data-financial", () => {
 
@@ -477,6 +479,99 @@
         assert.isFalse( stub.called );
 
         stub.restore();
+      } );
+
+    } );
+
+    suite( "_handleData", () => {
+      setup( () => {
+        element._instruments = instruments;
+      } );
+
+      teardown( () => {
+        element._instruments = [];
+        element.removeAttribute( "symbol" );
+      } );
+
+      test( "should send 'data-update' event with instruments and data", ( done ) => {
+        const listener = ( evt ) => {
+          assert.deepEqual( evt.detail, {
+            instruments: instruments,
+            data: realTimeData.table,
+          } );
+
+          element.removeEventListener( "data-update", listener );
+          done();
+        };
+
+        element.addEventListener( "data-update", listener );
+        element._handleData( { detail: [ realTimeData ] } );
+      } );
+
+      test( "should send 'data-update' event with instruments and data for a single instrument when symbol is set", ( done ) => {
+        const listener = ( evt ) => {
+          assert.deepEqual( evt.detail, {
+            instruments: [ inst2 ],
+            data: realTimeData.table,
+          } );
+
+          element.removeEventListener( "data-update", listener );
+          done();
+        };
+
+        element.setAttribute( "symbol", ".DJI" );
+        element._invalidSymbol = false;
+        element._instruments = instruments;
+
+        element.addEventListener( "data-update", listener );
+        element._handleData( { detail: [ realTimeData ] } );
+      } );
+
+      test( "should send 'data-update' event with instruments only when no table provided", ( done ) => {
+        const listener = ( evt ) => {
+          assert.deepEqual( evt.detail, {
+            instruments: instruments
+          } );
+
+          element.removeEventListener( "data-update", listener );
+          done();
+        };
+
+        element.addEventListener( "data-update", listener );
+        element._handleData( { detail: [ {} ] } );
+      } );
+
+      test( "should send 'data-error' event with detail when 'errors' prop present in response detail", ( done ) => {
+        const listener = ( evt ) => {
+          assert.deepEqual( evt.detail, {
+            detailed_message: "400: Test error message",
+            message: "Test error message"
+          } );
+
+          element.removeEventListener( "data-error", listener );
+          done();
+        };
+
+        element.addEventListener( "data-error", listener );
+        element._handleData( { detail: [ { errors: [ { detailed_message: "400: Test error message", message: "Test error message" } ] } ] } );
+      } );
+
+    } );
+
+    suite( "_handleError", () => {
+
+      test( "should send 'request-error' event with message provided from iron-jsonp-library", ( done ) => {
+        const listener = ( evt ) => {
+          assert.deepEqual( evt.detail, {
+            message: "Test error message"
+          } );
+
+          element.removeEventListener( "request-error", listener );
+          done();
+        };
+
+        element.addEventListener( "request-error", listener );
+        element.financialErrorMessage = "Test error message";
       } );
 
     } );


### PR DESCRIPTION
- Observing data bound `financialErrorMessage` prop to handle a JSONP request error facilitated by iron-jsonp-library element and sending _request-error_ event when it occurs
- Sending _data-update_ event when handling successful response, providing instruments in detail along with `table` data (if it's present). 
- Sending _data-error_ event when handling successful response but the detail of the response contains `errors` prop