### PR TITLE
Implement refresh and revise reset

### DIFF
--- a/test/integration/rise-data-financial-realtime.html
+++ b/test/integration/rise-data-financial-realtime.html
@@ -50,8 +50,8 @@
 
     suite( "financial list id change", () => {
 
-      test( "should call _financialReset()", () => {
-        let changedStub = sinon.stub( element, "_financialReset" );
+      test( "should call _reset()", () => {
+        let changedStub = sinon.stub( element, "_reset" );
 
         element.setAttribute( "financial-list", "abc123" );
         assert.isTrue( changedStub.calledOnce );

--- a/test/integration/rise-data-financial-realtime.html
+++ b/test/integration/rise-data-financial-realtime.html
@@ -21,6 +21,8 @@
   </template>
 </test-fixture>
 
+<script src="../data/realtime.js"></script>
+
 <script>
   suite("rise-data-financial", () => {
 
@@ -47,6 +49,32 @@
       clock.restore();
     } );
 
+    suite( "refresh", () => {
+      let spy;
+
+      setup( () => {
+        spy = sinon.spy( element, "_refresh" );
+      } );
+
+      teardown( () => {
+        spy.restore();
+      } );
+
+      test( "should start refresh timer on successful JSONP response", () => {
+        element._initialStart = false;
+        element._handleData( { detail: [ realTimeData ] } );
+
+        assert( spy.calledOnce );
+      } );
+
+      test( "should start refresh timer on failed JSON request", () => {
+        element._initialStart = false;
+        element._handleError();
+
+        assert( spy.calledOnce );
+      } );
+
+    } );
 
     suite( "financial list id change", () => {
 

--- a/test/unit/rise-data-financial-historical.html
+++ b/test/unit/rise-data-financial-historical.html
@@ -26,7 +26,7 @@
 
     let element,
       clock,
-      financialResetStub;
+      resetStub;
 
     setup(() => {
       RisePlayerConfiguration.getDisplayId = () => {
@@ -34,11 +34,11 @@
       };
 
       element = fixture("test-block");
-      financialResetStub = sinon.stub(element, "_financialReset");
+      resetStub = sinon.stub(element, "_reset");
     });
 
     teardown(() => {
-      financialResetStub.restore();
+      resetStub.restore();
       RisePlayerConfiguration.getDisplayId = {};
     });
 

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -50,7 +50,7 @@
 
     let element,
       clock,
-      financialResetStub;
+      _resetStub;
 
     setup(() => {
       RisePlayerConfiguration.getDisplayId = () => {
@@ -58,12 +58,12 @@
       };
 
       element = fixture("test-block");
-      financialResetStub = sinon.stub(element, "_financialReset");
+      _resetStub = sinon.stub(element, "_reset");
 
     });
 
     teardown(() => {
-      financialResetStub.restore();
+      _resetStub.restore();
       RisePlayerConfiguration.getDisplayId = {};
     });
 
@@ -576,7 +576,7 @@
 
     } );
 
-    suite( "_financialReset", () => {
+    suite( "_reset", () => {
       let instrumentsStub;
 
       setup( () => {
@@ -587,14 +587,16 @@
         instrumentsStub.restore();
       } );
 
-      test( "should call _getInstruments()", () => {
+      test( "should call _getInstruments() if not initial start", () => {
         // need to remove the stub and add back on every test
-        financialResetStub.restore();
-        element._financialReset();
+        _resetStub.restore();
+        element._initialStart = false;
+        element._reset();
 
+        assert.isTrue( element._getDataPending );
         assert.isTrue( instrumentsStub.calledOnce );
 
-        financialResetStub = sinon.stub( element, "_financialReset" );
+        _resetStub = sinon.stub( element, "_reset" );
       } );
 
     } );

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -127,11 +127,32 @@
 
     } );
 
+    suite( "_refresh", () => {
+
+      test( "should make a new request for data after 1 minute", () => {
+        const stub = sinon.stub( element, "_getData" );
+
+        element._refresh();
+
+        assert.isFalse( stub.calledOnce );
+
+        clock.tick( 60000 );
+
+        assert.isTrue( stub.calledWith({
+          duration: "1M",
+          type: "realtime"
+        }, element._instruments, [ "lastPrice", "netChange" ]) );
+
+        stub.restore();
+      } );
+
+    } );
+
     suite( "_getInstruments", () => {
       let spy;
 
       setup( () => {
-        spy = sinon.spy( element, "_handleInstruments" );
+        spy = sinon.stub( element, "_handleInstruments" );
       } );
 
       teardown( () => {
@@ -560,6 +581,8 @@
 
     suite( "_handleError", () => {
 
+      setup(() => element._initialStart = false);
+
       test( "should send 'request-error' event with message provided from iron-jsonp-library", ( done ) => {
         const listener = ( evt ) => {
           assert.deepEqual( evt.detail, {
@@ -652,25 +675,44 @@
 
     suite( "_handleStart", () => {
 
-      teardown( () => {
-        element._initialStart = true;
-      } );
-
       test( "should call _getData() when this is the initial 'start'", () => {
-        const spy = sinon.stub( element, "_getData" );
+        const stub = sinon.stub( element, "_getData" );
 
         element._instrumentsReceived = true;
 
         const event = new CustomEvent( "start" );
         element.dispatchEvent( event );
 
-        assert.isTrue( spy.calledOnce, "_getData is called" );
+        assert.isTrue( stub.calledWith({
+          duration: "1M",
+          type: "realtime"
+        }, element._instruments, [ "lastPrice", "netChange" ]) );
+
         assert.isFalse( element._initialStart, "_initialStart set to false" );
 
-        spy.restore();
+        stub.restore();
       } );
 
-      test( "should not call _getData() when this is not the initial start", () => {
+      test( "should call _getData() when this is not the initial 'start' but _getDataPending is true", () => {
+        const stub = sinon.stub( element, "_getData" );
+
+        element._instrumentsReceived = true;
+        element._getDataPending = true;
+
+        const event = new CustomEvent( "start" );
+        element.dispatchEvent( event );
+
+        assert.isTrue( stub.calledWith({
+          duration: "1M",
+          type: "realtime"
+        }, element._instruments, [ "lastPrice", "netChange" ]) );
+
+        assert.isFalse( element._initialStart, "_initialStart set to false" );
+
+        stub.restore();
+      } );
+
+      test( "should not call _getData() when this is not the initial start and _getDataPending is false", () => {
         const spy = sinon.stub( element, "_getData" );
 
         element._instrumentsReceived = true;


### PR DESCRIPTION
- Upon handling data or handling JSONP request error, a refresh timer of 1 min is started before it executes another retrieval of data from server
- Upon a reset (either `financialList` or `symbol` values were dynamically changed during runtime), flagging that getting  data is pending so when the consumer of component receives _instruments-received_ event and they dispatch _start_ event again, the component knows it should execute getting data. 