### PR TITLE
Fix/demo page and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 `rise-data-financial` is a Polymer 3 Web Component that works together with the [Rise Vision Financial Selector](https://selector.risevision.com/), a web app for managing financial content. It retrieves the financial list and its corresponding instruments from [Firebase](https://firebase.google.com/). Data is refreshed in realtime, so any changes that are made to a particular financial list in the Financial Selector are immediately propagated to the `rise-data-financial` component.
 
+Instructions for demo page here:
+https://github.com/Rise-Vision/rise-data-financial/blob/master/demo/README.md
+
 ## Usage
 The component has an external dependency on [Firebase](https://firebase.google.com/) and has not been built to bundle the required SDK libraries. This means the required Firebase libraries must be explicitly imported in the `<head>` of the HTML page that you are using the component. **_Note_**: The version of Firebase used below is just for example purposes.
 
@@ -21,7 +24,7 @@ The component has an external dependency on [Firebase](https://firebase.google.c
 </html>
 ```
 
-The below illustrates simple usage of the component and listening to the `rise-components-loaded` event to initiate. This is required in order to know that the component has been imported to the page. See the demo section in this repo for a full working example of an HTML page using the component which will illustrate required imports in the `<head>` of the page. 
+The below illustrates simple usage of the component and listening to the `rise-components-loaded` event to initiate. This is required in order to know that the component has been imported to the page. See the demo section in this repo for a full working example of an HTML page using the component which will illustrate required imports in the `<head>` of the page.
 
 ### Example
 
@@ -33,7 +36,7 @@ The below illustrates simple usage of the component and listening to the `rise-c
           console.log( "load process failed" );
           return;
         }
-        
+
         const financial = document.querySelector( "rise-data-financial" );
 
         financial.addEventListener( "instruments-received", () => {
@@ -46,17 +49,17 @@ The below illustrates simple usage of the component and listening to the `rise-c
           console.log( "data update", evt.detail );
         } );
       }
-      
+
       window.addEventListener( "rise-components-loaded", onComponentsLoaded);
     </script>
-    
+
     <rise-data-financial
       id="financial01"
       financial-list="-ABC123DEF456"
       instrument-fields='["instrument", "name", "lastPrice", "netChange"]'>
     </rise-data-financial>
 ...
-    
+
   </body>
 ```
 ### Realtime Data
@@ -110,15 +113,15 @@ _instruments_ is an object that provides details about every instrument found in
 
 The component sends the following events:
 
-- **_instruments-received_**: Instruments for the financial list provided have been successfully received from Firebase. The component is ready to execute getting data by dispatching _start_ event on the component. 
-- **_instruments-unavailable_**: Instruments were not able to be retrieved and the component will not be able to execute getting data. Potential reasons could be no network, required Firebase imports were not included in HTML page, or the financial list provided was not found. 
+- **_instruments-received_**: Instruments for the financial list provided have been successfully received from Firebase. The component is ready to execute getting data by dispatching _start_ event on the component.
+- **_instruments-unavailable_**: Instruments were not able to be retrieved and the component will not be able to execute getting data. Potential reasons could be no network, required Firebase imports were not included in HTML page, or the financial list provided was not found.
 - **_data-update_**: Data has been retrieved and the data object is provided in `event.detail`
 - **_data-error_**: The financial server responded with a Error and the object is provided in `event.detail`
-- **_request-error_**: There was a problem making the JSONP request to Financial server and the message object is provided in `event.detail`. 
+- **_request-error_**: There was a problem making the JSONP request to Financial server and the message object is provided in `event.detail`.
 
 The component is listening for the following events:
 
-- **_start_**: This event will initiate getting data from Financial server. It can be dispatch on the component when _instruments-received_ event has been fired as that event indicates the component successfully retrieved instruments and is ready to make a request to the Financial server to retrieve data. 
+- **_start_**: This event will initiate getting data from Financial server. It can be dispatch on the component when _instruments-received_ event has been fired as that event indicates the component successfully retrieved instruments and is ready to make a request to the Financial server to retrieve data.
 
 
 
@@ -137,8 +140,8 @@ Clone this repo and change into this project directory.
 Execute the following commands in Terminal:
 
 ```
-npm install 
-npm install -g polymer-cli 
+npm install
+npm install -g polymer-cli
 npm run build
 ```
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -35,12 +35,16 @@ The below options illustrate different ways to run this demo, however option A i
 #### ChrOS Player as Packaged App in Chrome browser
 
 All the contents of _build/prod_ must be uploaded to Rise Storage.
+To avoid CORS issues, the server domain of the published file must be
+risevision.com.
 
 Then create a schedule that targets the URL of the published file, for example:
 
-`https://storage.googleapis.com/risemedialibrary-xxxxx-yyyy-xxx/src/rise-data-financial-chromeos.html`
+`http://widgets.risevision.com/staging/pages/2018.XX.XX.XX.XX/src/rise-data-financial-chromeos.html`
 
 Then configure the local environment as described in the [Financial Templates First - Local Development](https://docs.google.com/document/d/1xbtDo9GnhbH0lGeQmgTdSb-U5ed0vTjufhxZBV-1C4A/edit) document.
+It's not necessary to point the schedule to a local URL as it's described
+there, with the above URL for the schedule is enough.
 
 Once the application has been configured and ran, there will not be any visual aspects to the demo. You can view the dev console (follow instructions in document) and you will see logs pertaining to the component and eventual data retrieved.
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -42,6 +42,8 @@ Then create a schedule that targets the URL of the published file, for example:
 
 `http://widgets.risevision.com/staging/pages/2018.XX.XX.XX.XX/src/rise-data-financial-chromeos.html`
 
+Note that this is an HTTP URL, as ChromeOS currently requires that.
+
 Then configure the local environment as described in the [Financial Templates First - Local Development](https://docs.google.com/document/d/1xbtDo9GnhbH0lGeQmgTdSb-U5ed0vTjufhxZBV-1C4A/edit) document.
 It's not necessary to point the schedule to a local URL as it's described
 there, with the above URL for the schedule is enough.

--- a/demo/src/rise-data-financial-chromeos.html
+++ b/demo/src/rise-data-financial-chromeos.html
@@ -18,13 +18,13 @@
   <script type="module">
     import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
   </script>
-  <script src="http://widgets.risevision.com/beta/common/config-test.js"></script>
-  <script src="http://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
-  <script src="http://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
-  <script src="http://widgets.risevision.com/beta/common/rise-helpers.js"></script>
-  <script src="http://widgets.risevision.com/beta/common/rise-logger.js"></script>
-  <script src="http://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
-  <script src="http://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/config-test.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
+  <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
   <script>
     if (document.domain.indexOf("localhost") === -1) {
       try {

--- a/demo/src/rise-data-financial-chromeos.html
+++ b/demo/src/rise-data-financial-chromeos.html
@@ -18,13 +18,13 @@
   <script type="module">
     import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
   </script>
-  <script src="https://widgets.risevision.com/beta/common/config-test.js"></script>
-  <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
-  <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
-  <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
-  <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
-  <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
-  <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/config-test.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/rise-helpers.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/rise-logger.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
+  <script src="http://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
   <script>
     if (document.domain.indexOf("localhost") === -1) {
       try {


### PR DESCRIPTION
Demo page for ChromeOS needs to use HTTP, and the README file should also mention that HTTP should be used for ChromeOS.

I also added the requirement for risevision.com domain for demo pages, and some clarifications for instructions that resulted in confusion.
