### PR TITLE
Chore/include display id in demo

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+demo/node_modules/**
 node_modules/**
 build
 dist

--- a/demo/src/rise-data-financial-chromeos.html
+++ b/demo/src/rise-data-financial-chromeos.html
@@ -40,7 +40,7 @@
 
     // electron / websocket or chromeos / window
     RisePlayerConfiguration.configure({
-      displayId: "Y8SAH3CQ6NMP",
+      displayId: "DISPLAY_ID",
       companyId: "COMPANY_ID",
       playerType: "beta",
       playerVersion: "TEST_VERSION",

--- a/demo/src/rise-data-financial-chromeos.html
+++ b/demo/src/rise-data-financial-chromeos.html
@@ -40,6 +40,8 @@
 
     // electron / websocket or chromeos / window
     RisePlayerConfiguration.configure({
+      displayId: "Y8SAH3CQ6NMP",
+      companyId: "COMPANY_ID",
       playerType: "beta",
       playerVersion: "TEST_VERSION",
       os: "TEST_OS"

--- a/demo/src/rise-data-financial-electron.html
+++ b/demo/src/rise-data-financial-electron.html
@@ -40,7 +40,7 @@
 
     // electron / websocket or chromeos / window
     RisePlayerConfiguration.configure({
-      displayId: "Y8SAH3CQ6NMP",
+      displayId: "DISPLAY_ID",
       companyId: "COMPANY_ID",
       playerType: "beta",
       playerVersion: "TEST_VERSION",

--- a/demo/src/rise-data-financial-electron.html
+++ b/demo/src/rise-data-financial-electron.html
@@ -40,6 +40,8 @@
 
     // electron / websocket or chromeos / window
     RisePlayerConfiguration.configure({
+      displayId: "Y8SAH3CQ6NMP",
+      companyId: "COMPANY_ID",
       playerType: "beta",
       playerVersion: "TEST_VERSION",
       os: "TEST_OS"


### PR DESCRIPTION
I included it also here, 

to remove the temporary event that sets the display we could use this other card in backlog: https://trello.com/c/zRFyCHlE/6068-as-the-financial-component-once-im-initialized-i-am-able-to-confirm-my-display-id-so-that-i-can-log-errors-and-events-to-the-cli
