### PR TITLE
Chore/e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
   gcloud-setup:
     docker: &GCSIMAGE
       - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
+        environment:
+          WIDGETS_BASE: gs://widgets.risevision.com
     steps:
       - run: mkdir -p ~/.ssh
       - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
@@ -114,11 +116,30 @@ jobs:
       - run: cp -r gcloud ~/.config
       - run: npm install common-component
       - run: |
-          GS_BASE=gs://widgets.risevision.com
           VERSION=$(cat version-string/version)
-          TARGET=$GS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
+          TARGET=$WIDGETS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
           node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
+
+  deploy-e2e-page:
+    parameters:
+      stage:
+        type: string
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: |
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/e2e/$COMPONENT_NAME/electron
+          echo Deploying << parameters.stage >> electron e2e page for $COMPONENT_NAME
+          gsutil rsync -d -r base $TARGET
+          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
+          gsutil acl -r ch -u AllUsers:R $TARGET
 
   deploy-production:
     parameters:
@@ -135,8 +156,7 @@ jobs:
       - run: cp -r gcloud ~/.config
       - run: npm install common-component
       - run: |
-          GS_BASE=gs://widgets.risevision.com
-          TARGET=$GS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
           echo Deploying << parameters.stage >> version of $COMPONENT_NAME
           node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
@@ -206,6 +226,27 @@ workflows:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - build/stable
+      - deploy-e2e-page:
+          stage: beta
+          name: deploy-e2e-page-beta
+          requires:
+            - gcloud-setup
+            - build-e2e-page-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^(stage|staging)[/].*/
+      - deploy-e2e-page:
+          stage: stable
+          name: deploy-e2e-page-stable
+          requires:
+            - gcloud-setup
+            - build-e2e-page-stable
+          filters:
+            branches:
+              only:
                 - build/stable
       - deploy-production:
           stage: beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -280,7 +279,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -302,7 +300,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           displayId: WHQZ8NK8KFSM
           installerPath: /

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,25 +155,30 @@ jobs:
           PLAYER_CONFIG: /home/circleci/rvplayer/RiseDisplayNetworkII.ini
     steps:
       - run: git clone https://github.com/Rise-Vision/rise-launcher-electron-e2e.git
-      - run: |
-          cd rise-launcher-electron-e2e
-          npm install
-      - run: mkdir ~/rvplayer
-      - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
-      - run: echo proxy= >> $PLAYER_CONFIG
       - run:
-          name: prepare the test
+          working_directory: rise-launcher-electron-e2e
+          command: npm install
+      - run: mkdir ~/rvplayer
+      - run:
+          name: setup rise player configuration file
+          command: |
+            echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
+            echo proxy= >> $PLAYER_CONFIG
+      - run:
+          name: download expected screenshot
+          working_directory: rise-launcher-electron-e2e
           command: |
             EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
-            cd rise-launcher-electron-e2e
             curl $EXPECTED_SNAPSHOT_URL > expected-screenshot.jpg
-            curl $INSTALLER_BASE<< parameters.installerPath >>installer-lnx-64.sh > installer.sh
-            chmod +x installer.sh
+      - run:
+          name: download Rise Player Electron
+          working_directory: rise-launcher-electron-e2e
+          command: curl $INSTALLER_BASE<< parameters.installerPath >>installer-lnx-64.sh > installer.sh
+      - run: chmod +x ./rise-launcher-electron-e2e/installer.sh
       - run:
           name: run the test
-          command: |
-            cd rise-launcher-electron-e2e
-            node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
+          working_directory: rise-launcher-electron-e2e
+          command: node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
       - run: mkdir output
       - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,33 @@ jobs:
           paths:
             - version-string
 
+  build-e2e-page:
+    parameters:
+      stage:
+        type: string
+    docker: *BUILDIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: echo build e2e page << parameters.stage >>
+      - run: |
+          VERSION=$(cat version-string/version)
+          sed "
+            s/__STAGE__/<< parameters.stage >>/;
+            s/__VERSION__/$VERSION/;
+            s/__PLAYER__/electron/;
+            s/__CONNECTION__/websocket/;
+          " e2e/rise-data-financial.html > e2e/rise-data-financial-electron.html
+      - run: cp e2e/polymer-e2e-electron.json polymer.json
+      - run: polymer build
+      - persist_to_workspace:
+          root: ./build
+          paths:
+            - base
+
   deploy-stage:
     docker: *GCSIMAGE
     steps:
@@ -150,6 +177,25 @@ workflows:
               only:
                 - /^(stage|staging)[/].*/
                 - master
+                - build/stable
+      - build-e2e-page:
+          stage: beta
+          name: build-e2e-page-beta
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - /^(stage|staging)[/].*/
+      - build-e2e-page:
+          stage: stable
+          name: build-e2e-page-stable
+          requires:
+            - build
+          filters:
+            branches:
+              only:
                 - build/stable
       - deploy-stage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,44 @@ jobs:
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
 
+  test-e2e-electron:
+    parameters:
+      displayId:
+        type: string
+      installerPath:
+        type: string
+    docker: &E2EIMAGE
+      - image: jenkinsrise/jenkinsrise-cci-image-launcher-electron-e2e:0.0.2
+        environment:
+          INSTALLER_BASE: https://storage.googleapis.com/install-versions.risevision.com
+          SCREENSHOTS_BASE: https://storage.googleapis.com/risevision-display-screenshots
+          PLAYER_CONFIG: /home/circleci/rvplayer/RiseDisplayNetworkII.ini
+    steps:
+      - run: git clone https://github.com/Rise-Vision/rise-launcher-electron-e2e.git
+      - run: |
+          cd rise-launcher-electron-e2e
+          npm install
+      - run: mkdir ~/rvplayer
+      - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
+      - run: echo proxy= >> $PLAYER_CONFIG
+      - run:
+          name: prepare the test
+          command: |
+            EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
+            cd rise-launcher-electron-e2e
+            curl $EXPECTED_SNAPSHOT_URL > expected-screenshot.jpg
+            curl $INSTALLER_BASE<< parameters.installerPath >>installer-lnx-64.sh > installer.sh
+            chmod +x installer.sh
+      - run:
+          name: run the test
+          command: |
+            cd rise-launcher-electron-e2e
+            node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
+      - run: mkdir output
+      - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
+      - store_artifacts:
+          path: output
+
   deploy-production:
     parameters:
       stage:
@@ -248,20 +286,43 @@ workflows:
             branches:
               only:
                 - build/stable
+      - test-e2e-electron:
+          displayId: 2D56PH7272AW
+          installerPath: /beta/
+          name: test-e2e-electron-beta
+          requires:
+            - deploy-stage
+            - deploy-e2e-page-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^(stage|staging)[/].*/
+      - test-e2e-electron:
+          displayId: WHQZ8NK8KFSM
+          installerPath: /
+          name: test-e2e-electron-stable
+          requires:
+            - deploy-stage
+            - deploy-e2e-page-stable
+          filters:
+            branches:
+              only:
+                - build/stable
       - deploy-production:
           stage: beta
+          name: deploy-beta
           requires:
-            - gcloud-setup
-            - build
+            - test-e2e-electron-beta
           filters:
             branches:
               only:
                 - master
       - deploy-production:
           stage: stable
+          name: deploy-stable
           requires:
-            - gcloud-setup
-            - build
+            - test-e2e-electron-stable
           filters:
             branches:
               only:

--- a/e2e/polymer-e2e-electron.json
+++ b/e2e/polymer-e2e-electron.json
@@ -1,0 +1,21 @@
+{
+  "entrypoint": "e2e/rise-data-financial-electron.html",
+  "sources": [ "e2e/**/*" ],
+  "extraDependencies": [
+    "node_modules/@polymer/polymer/**",
+    "node_modules/@webcomponents/webcomponentsjs/**"
+  ],
+  "builds": [
+    {
+      "name": "base",
+      "preset": "es5-bundled",
+      "addServiceWorker": false,
+      "html": { "minify": true },
+      "css": { "minify": true },
+      "js": { "minify": true },
+      "bundle": { "stripComments": true }
+    }
+  ],
+  "moduleResolution": "node",
+  "npm": true
+}

--- a/e2e/rise-data-financial.html
+++ b/e2e/rise-data-financial.html
@@ -1,0 +1,104 @@
+<!doctype html>
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- import firebase from CDN, bundling into rise-data-financial not possible -->
+    <script src="https://www.gstatic.com/firebasejs/5.5.3/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/5.5.3/firebase-database.js"></script>
+
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js"></script>
+    <script type="module">
+      // this and the following block are needed at build time to force the creation of the shared bundle script
+      import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+    </script>
+    <script type="module">
+      import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+    </script>
+    <script src="https://widgets.risevision.com/__STAGE__/common/config-test.min.js"></script>
+    <script src="https://widgets.risevision.com/__STAGE__/common/common-template.min.js"></script>
+    <script src="https://widgets.risevision.com/staging/components/rise-data-financial/__VERSION__/rise-data-financial.js"></script>
+    <script>
+      if (document.domain.indexOf("localhost") === -1) {
+        try {
+          document.domain = "risevision.com";
+        } catch (err) {
+          // can't set document.domain, risevision.com not an accepted suffix of current document domain
+          console.log("document.domain can't be set", err);
+        }
+      }
+    </script>
+    <style>
+       h1 { font-size: 72px; }
+    </style>
+  </head>
+  <body>
+    <rise-data-financial
+      id="rise-data-financial-01"
+      financial-list = "-Kd1xh1DkzpmBeCdfLiB"
+      instrument-fields='["name", "lastPrice", "netChange", "percentChange", "accumulatedVolume"]'>
+    </rise-data-financial>
+
+    <h1 id="instruments"></h1>
+    <h1 id="data"></h1>
+
+    <script>
+      function configureComponents() {
+        const start = new CustomEvent( "start" ),
+          financial01 = document.querySelector('#rise-data-financial-01');
+
+        financial01.addEventListener( "instruments-received", ( evt ) => {
+          console.log("instruments received", evt.detail);
+          document.querySelector('#instruments').innerHTML = "INSTRUMENTS";
+
+          console.log("dispatching 'start' event");
+          financial01.dispatchEvent(start);
+        } );
+
+        financial01.addEventListener( "instruments-unavailable", () => {
+          console.log("instruments unavailable");
+        } );
+
+        financial01.addEventListener( "data-update", ( evt ) => {
+          console.log( "data update", evt.detail );
+          document.querySelector('#data').innerHTML = "DATA";
+        } );
+
+        financial01.addEventListener( "data-error", ( evt ) => {
+          console.log( "data error", evt.detail );
+        } );
+
+        financial01.addEventListener( "request-error", ( evt ) => {
+          console.log( "request error", evt.detail );
+        } );
+      }
+
+      window.addEventListener( "rise-components-ready", configureComponents );
+
+      // Demonstrating how to handle no connection to local messaging via listening for event
+      // Note: the connection can also be checked via RisePlayerConfiguration.LocalMessaging.isConnected()
+      window.addEventListener( "rise-local-messaging-connection", event => {
+        if ( !event.detail.isConnected ) {
+          console.log( "no connection to local messaging");
+        }
+      } );
+    </script>
+    <script>
+      // electron / websocket or chromeos / window
+      RisePlayerConfiguration.configure({
+        displayId: "Y8SAH3CQ6NMP",
+        companyId: "7fa5ee92-7deb-450b-a8d5-e5ed648c575f",
+        playerType: "__STAGE__",
+        playerVersion: "TEST_VERSION",
+        os: "TEST_OS"
+      }, {
+        player: "__PLAYER__",
+        connectionType: "__CONNECTION__",
+        detail: { serverUrl: "http://localhost:8080" }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
The e2e test updates the page on "instruments received" and "data update" events. The updated screen represents the screenshot that represents successful completion of the test.

Dedicated beta display id: 2D56PH7272AW
Dedicated stable display id: WHQZ8NK8KFSM
  
e2e running here: https://circleci.com/workflow-run/f735b774-c368-4464-9fd3-bbea6891d560

Beta page published here:
  https://console.cloud.google.com/storage/browser/widgets.risevision.com/beta/e2e/rise-data-financial/electron/e2e/?project=avid-life-623

Beta schedule for e2e:
  https://apps.risevision.com/schedules/details/3343cfc2-d99f-481c-8939-61ecdcb8336d?cid=f114ad26-949d-44b4-87e9-8528afc76ce4

Stable schedule for e2e:
  https://apps.risevision.com/schedules/details/cafb5922-4996-4bba-b531-fd112f548260?cid=f114ad26-949d-44b4-87e9-8528afc76ce4&cHJpb3JpdHktc3VwcG9ydA=1

Beta expected screenshot:
  https://console.cloud.google.com/storage/browser/risevision-display-screenshots?project=display-messaging-service&prefix=2D56PH7272AW

Stable expected screenshot:
  https://console.cloud.google.com/storage/browser/risevision-display-screenshots?project=display-messaging-service&prefix=WHQZ8NK8KFSM
