### PR TITLE
Fix/timing issue

### DIFF
--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -124,11 +124,11 @@ class RiseDataFinancial extends PolymerElement {
   ready() {
     super.ready();
 
-    const init = () => this._init();
-
     if ( RisePlayerConfiguration.isConfigured()) {
-      init();
+      this._init();
     } else {
+      const init = () => this._init();
+
       window.addEventListener( "rise-components-ready", init, { once: true });
     }
   }

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -124,6 +124,16 @@ class RiseDataFinancial extends PolymerElement {
   ready() {
     super.ready();
 
+    const init = () => this._init();
+
+    if ( RisePlayerConfiguration.isConfigured()) {
+      init();
+    } else {
+      window.addEventListener( "rise-components-ready", init, { once: true });
+    }
+  }
+
+  _init() {
     const display_id = RisePlayerConfiguration.getDisplayId();
 
     if ( display_id && typeof display_id === "string" && display_id !== "DISPLAY_ID" ) {

--- a/test/index.html
+++ b/test/index.html
@@ -16,7 +16,8 @@
     "integration/rise-data-financial-realtime.html",
     "integration/rise-data-financial-logging.html",
     "unit/rise-data-financial.html",
-    "unit/rise-data-financial-historical.html"
+    "unit/rise-data-financial-historical.html",
+    "unit/rise-data-financial-not-configured.html"
   ] );
 </script>
 </body>

--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -9,7 +9,9 @@
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script src="../mocks/firebase.js"></script>
   <script type="text/javascript">
-    RisePlayerConfiguration = {};
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
   </script>
   <script src="../../src/rise-data-financial-config.js" type="module"></script>
   <script src="../../src/rise-data-financial.js" type="module"></script>

--- a/test/integration/rise-data-financial-realtime.html
+++ b/test/integration/rise-data-financial-realtime.html
@@ -9,7 +9,9 @@
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script src="../mocks/firebase.js"></script>
   <script type="text/javascript">
-    RisePlayerConfiguration = {};
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
   </script>
   <script src="../../src/rise-data-financial-config.js" type="module"></script>
   <script src="../../src/rise-data-financial.js" type="module"></script>

--- a/test/unit/rise-data-financial-historical.html
+++ b/test/unit/rise-data-financial-historical.html
@@ -9,7 +9,9 @@
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script src="../mocks/firebase.js"></script>
   <script type="text/javascript">
-    RisePlayerConfiguration = {};
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
   </script>
   <script src="../../src/rise-data-financial-config.js" type="module"></script>
   <script src="../../src/rise-data-financial.js" type="module"></script>

--- a/test/unit/rise-data-financial-not-configured.html
+++ b/test/unit/rise-data-financial-not-configured.html
@@ -1,0 +1,61 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+  <script src="../mocks/firebase.js"></script>
+  <script type="text/javascript">
+    RisePlayerConfiguration = {
+      isConfigured: () => false,
+      getDisplayId: () => "ABC123",
+      Logger: {
+        info: () => {},
+        warning: () => {},
+        error: () => {}
+      }
+    };
+  </script>
+  <script src="../../src/rise-data-financial-config.js" type="module"></script>
+  <script src="../../src/rise-data-financial.js" type="module"></script>
+</head>
+<body>
+<test-fixture id="test-block">
+  <template>
+    <rise-data-financial financial-list="Stocks" instrument-fields='["lastPrice", "netChange"]'></rise-data-financial>
+  </template>
+</test-fixture>
+
+<script src="../data/realtime.js"></script>
+
+<script>
+  suite("rise-data-financial-not-configured", () => {
+
+    let element;
+
+    setup(() => {
+      element = fixture("test-block");
+    });
+
+    suite( "_init", () => {
+
+      test( "should not set display id after rise-components-ready is not called", () => {
+        assert.equal( element.displayId, "preview" );
+      } );
+
+      test( "should set display id after rise-components-ready is called", () => {
+        window.dispatchEvent( new CustomEvent( "rise-components-ready" ));
+
+        assert.equal( element.displayId, "ABC123" );
+      } );
+
+    } );
+
+  });
+</script>
+
+</body>
+</html>

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -9,7 +9,9 @@
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   <script src="../mocks/firebase.js"></script>
   <script type="text/javascript">
-    RisePlayerConfiguration = {};
+    RisePlayerConfiguration = {
+      isConfigured: () => true
+    };
   </script>
   <script src="../../src/rise-data-financial-config.js" type="module"></script>
   <script src="../../src/rise-data-financial.js" type="module"></script>


### PR DESCRIPTION
if `RisePlayerConfiguration.configure()` hasn't been called, the displayId initialization is postponed until `rise-components-ready` event is received.

I added a test file for this case.

I tested manually on both electron and chromeos local.
