### PR TITLE
Retry failed financial requests

### DIFF
--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -171,19 +171,31 @@
       }, 500);
     });
 
-    test( "should log 'request-error' error event", () => {
+    test( "should log 'request-error' error event after 5 failed retries", () => {
       element._initialStart = false;
-      element.financialErrorMessage = "test error";
 
       sinon.stub( element, "_refresh" );
+      sinon.stub( element, "_getData" );
 
-      element._handleError();
+      // force value for observed financialErrorMessage property to emulate failed financial request
+      element.financialErrorMessage = "test error";
+      // account for 1 second delay
+      clock.tick( 1000 );
+
+      assert.equal( RisePlayerConfiguration.Logger.error.callCount, 0 );
+
+      // emulate further retry failures
+      for ( let i = 0; i < 5; i += 1 ) {
+        element.financialErrorMessage = "test error";
+        clock.tick( 1000 );
+      }
 
       assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
       assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "request-error");
       assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], { message: "test error" } );
 
       element._refresh.restore();
+      element._getData.restore();
     } );
 
     test( "should log 'data-error' error event", () => {

--- a/test/integration/rise-data-financial-realtime.html
+++ b/test/integration/rise-data-financial-realtime.html
@@ -78,9 +78,23 @@
 
       test( "should start refresh timer on failed JSON request", () => {
         element._initialStart = false;
-        element._handleError();
+
+        sinon.stub( element, "_getData" );
+
+        // force value for observed financialErrorMessage property to emulate failed financial request
+        element.financialErrorMessage = "test error";
+        // account for 1 second delay
+        clock.tick( 1000 );
+
+        // emulate further retry failures
+        for ( let i = 0; i < 5; i += 1 ) {
+          element.financialErrorMessage = "test error";
+          clock.tick( 1000 );
+        }
 
         assert( spy.calledOnce );
+
+        element._getData.restore();
       } );
 
     } );

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -592,18 +592,54 @@
 
       setup(() => element._initialStart = false);
 
-      test( "should send 'request-error' event with message provided from iron-jsonp-library", ( done ) => {
+      test( "should send 'request-error' event with message after 5 failed retries", ( done ) => {
         const listener = ( evt ) => {
           assert.deepEqual( evt.detail, {
             message: "Test error message"
           } );
 
+          // retry count is reset
+          assert.equal( element._financialRequestRetryCount, 0 );
+
           element.removeEventListener( "request-error", listener );
+          element._getData.restore();
+
           done();
         };
 
+        const stub = sinon.stub( element, "_getData" );
+
         element.addEventListener( "request-error", listener );
+
+        // force value for observed financialErrorMessage property to emulate failed financial request
         element.financialErrorMessage = "Test error message";
+
+        // account for 1 second delay
+        clock.tick( 1000 );
+
+        assert.equal( stub.callCount, 1 );
+        assert.isTrue( stub.calledWith({
+          duration: "1M",
+          type: "realtime"
+        }, element._instruments, [ "lastPrice", "netChange" ]) );
+
+        element.financialErrorMessage = "Test error message";
+
+        // account for 1 second delay
+        clock.tick( 1000 );
+
+        assert.equal( stub.callCount, 2 );
+
+        // emulate further retry failures
+        for ( let i = 0; i < 3; i += 1 ) {
+          element.financialErrorMessage = "Test error message";
+          clock.tick( 1000 );
+        }
+
+        assert.equal( stub.callCount, 5 );
+
+        element.financialErrorMessage = "Test error message";
+        clock.tick( 1000 );
       } );
 
     } );


### PR DESCRIPTION
- Upon a JSONP request failure, retry the request again, every 1 second, for a maximum 5 attempts, before finally sending _request-error_ event and logging an error to BQ. 
- This is to handle the small amount of `request error` events logged by some displays. The overwhelming majority of requests are successful for these displays, so this hopefully reduces these rare failure cases from impacting reliability. 