### PR TITLE
Feature/log events as errors

### DIFF
--- a/demo/src/rise-data-financial.html
+++ b/demo/src/rise-data-financial.html
@@ -49,7 +49,7 @@
         financial01 = document.querySelector('#rise-data-financial-01');
 
       financial01.addEventListener( "instruments-received", ( evt ) => {
-        console.log("instruments received", evt.detail);
+        console.log( "instruments received", JSON.stringify(evt.detail) );
 
         console.log("dispatching 'start' event");
         financial01.dispatchEvent(start);
@@ -60,7 +60,7 @@
       } );
 
       financial01.addEventListener( "data-update", ( evt ) => {
-        console.log( "data update", evt.detail );
+        console.log( "data update", JSON.stringify(evt.detail) );
       } );
 
       financial01.addEventListener( "data-error", ( evt ) => {

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -108,6 +108,14 @@ class RiseDataFinancial extends PolymerElement {
     return "invalid-symbol";
   }
 
+  static get ERROR_EVENTS() {
+    return {
+      "N/P": "Rise is not permissioned to show the instrument",
+      "N/A": "Instrument is unavailable, invalid or unknown",
+      "S/P": "Display is not permissioned to show the instrument"
+    };
+  }
+
   constructor() {
     super();
 
@@ -120,6 +128,7 @@ class RiseDataFinancial extends PolymerElement {
     this._getDataPending = false;
     this._logDataUpdate = true;
     this._financialRequestRetryCount = 0;
+    this._eventsAlreadyLogged = [];
   }
 
   ready() {
@@ -390,6 +399,16 @@ class RiseDataFinancial extends PolymerElement {
     }
 
     this._refresh();
+  }
+
+  _checkFinancialErrors( data ) {
+    const symbols = data.instruments.map(({ symbol }) => symbol ).join( "|" );
+
+    Object.keys( RiseDataFinancial.ERROR_EVENTS ).forEach( status => {
+      console.log( symbols );
+      console.log( status );
+      console.log( RiseDataFinancial.ERROR_EVENTS[ status ]);
+    });
   }
 
   _getSymbols( instruments ) {

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -775,6 +775,117 @@
 
     } );
 
+    suite( "_checkFinancialErrors", () => {
+
+      var sampleData;
+
+      setup( () => {
+        sampleData = {
+        	"instruments": [{
+        		"$id": "%2EAV%2EN",
+        		"category": "Market Statistics",
+        		"name": "NYSE MOST ACTIVES",
+        		"symbol": ".AV.N"
+        	}],
+        	"data": {
+        		"cols": [],
+        		"rows": [{
+        			"c": [{
+        				"v": ""
+        			}, {
+        				"v": 0
+        			}, {
+        				"v": 0
+        			}, {
+        				"v": 0
+        			}, {
+        				"v": 0
+        			}]
+        		}, {
+        			"c": [{
+        				"v": ""
+        			}, {
+        				"v": 0
+        			}, {
+        				"v": 0
+        			}, {
+        				"v": 0
+        			}, {
+        				"v": 0
+        			}]
+        		}]
+        	}
+        }
+      } );
+
+      test( "should not log if no status are present in the data", () => {
+        const stub = sinon.stub( element, "_log" );
+
+        element._checkFinancialErrors( sampleData );
+
+        assert.isFalse( stub.called );
+        assert.deepEqual( element._eventsAlreadyLogged, [] );
+
+        stub.restore();
+      } );
+
+      test( "should log N/P error if it's present in the data", () => {
+        const stub = sinon.stub( element, "_log" );
+
+        sampleData.data.rows[0].c[0].v = "N/P";
+
+        element._checkFinancialErrors( sampleData );
+
+        assert.isTrue( stub.calledWith(
+          "error",
+          "Rise is not permissioned to show the instrument .AV.N"
+        ));
+
+        assert.deepEqual( element._eventsAlreadyLogged, ["N/P"] );
+
+        stub.restore();
+      } );
+
+      test( "should log N/P and S/P error if both are present in the data", () => {
+        const stub = sinon.stub( element, "_log" );
+
+        sampleData.data.rows[0].c[0].v = "N/P";
+        sampleData.data.rows[1].c[0].v = "S/P";
+
+        element._checkFinancialErrors( sampleData );
+
+        assert.isTrue( stub.calledWith(
+          "error",
+          "Rise is not permissioned to show the instrument .AV.N"
+        ));
+        assert.isTrue( stub.calledWith(
+          "error",
+          "Display is not permissioned to show the instrument .AV.N"
+        ));
+
+        assert.deepEqual( element._eventsAlreadyLogged, ["N/P", "S/P"] );
+
+        stub.restore();
+      } );
+
+      test( "should log errors if they were already logged", () => {
+        const stub = sinon.stub( element, "_log" );
+
+        sampleData.data.rows[0].c[0].v = "N/P";
+        sampleData.data.rows[1].c[0].v = "S/P";
+
+        element._eventsAlreadyLogged = ["N/P", "S/P"];
+
+        element._checkFinancialErrors( sampleData );
+
+        assert.isFalse( stub.called );
+        assert.deepEqual( element._eventsAlreadyLogged, ["N/P", "S/P"] );
+
+        stub.restore();
+      } );
+
+    } );
+
   });
 </script>
 

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -781,40 +781,20 @@
 
       setup( () => {
         sampleData = {
-        	"instruments": [{
-        		"$id": "%2EAV%2EN",
-        		"category": "Market Statistics",
-        		"name": "NYSE MOST ACTIVES",
-        		"symbol": ".AV.N"
-        	}],
-        	"data": {
-        		"cols": [],
-        		"rows": [{
-        			"c": [{
-        				"v": ""
-        			}, {
-        				"v": 0
-        			}, {
-        				"v": 0
-        			}, {
-        				"v": 0
-        			}, {
-        				"v": 0
-        			}]
-        		}, {
-        			"c": [{
-        				"v": ""
-        			}, {
-        				"v": 0
-        			}, {
-        				"v": 0
-        			}, {
-        				"v": 0
-        			}, {
-        				"v": 0
-        			}]
-        		}]
-        	}
+          "instruments": [{
+            "$id": "%2EAV%2EN",
+            "category": "Market Statistics",
+            "name": "NYSE MOST ACTIVES",
+            "symbol": ".AV.N"
+          }],
+          "data": {
+            "cols": [],
+            "rows": [{
+              "c": [{ "v": "" }, { "v": 0 }, { "v": 0 }, { "v": 0 }, { "v": 0 }]
+            }, {
+              "c": [{ "v": "" }, { "v": 0 }, { "v": 0 }, { "v": 0 }, { "v": 0 }]
+            }]
+          }
         }
       } );
 


### PR DESCRIPTION
When detecting N/P N/A S/P on the event structure, error logs will be send to BQ.

Unit tests were created.

Data was formatted in demo, so it's easier to inspect the data structures.

Can manually be tested by running this schedule:
https://apps.risevision.com/schedules/details/710a1da0-8e90-43f4-9836-f8dfbdb03fae?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013
( note: this staged version does console.log instead of logging to BQ )
