### PR TITLE
Upgrade and keep version of Polymer at 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Execute the following commands in Terminal:
 
 ```
 npm install
-npm install -g polymer-cli
+npm install -g polymer-cli@1.9.7
 npm run build
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,11 @@
       }
     },
     "@polymer/polymer": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.5.tgz",
-      "integrity": "sha512-Zbmhtr5vZ3NoHWwFYLKI4ff7yfE6DZopI8vaS7HvmUIuNqsv/EpEDXfNEYjqePQmkMX5LU9OIKV1eX/+9aveow==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.1.0.tgz",
+      "integrity": "sha512-hwN8IMERsFATz/9dSMxYHL+84J9uBkPuuarxJWlTsppZ4CAYTZKnepBfNrKoyNsafBmA3yXBiiKPPf+fJtza7A==",
       "requires": {
-        "@webcomponents/shadycss": "^1.2.0"
+        "@webcomponents/shadycss": "^1.5.2"
       }
     },
     "@polymer/sinonjs": {
@@ -53,9 +53,9 @@
       "dev": true
     },
     "@webcomponents/shadycss": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.5.2.tgz",
-      "integrity": "sha512-0OyrmVc7S+INtzoqP2ofAo+OdVn2Nj0Qvq4wD9FEGN7nMmLRxaD2mzy6hD6EslzxUSuGH302CDU4KXiY66SEqg=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.1.tgz",
+      "integrity": "sha512-IaZOnWOKXHghqk/WfPNDRIgDBi3RsVPY2IFAw6tYiL9UBGvQRy5R6uC+Fk7qTZsReTJ0xh5MTT8yAcb3MUR4mQ=="
     },
     "@webcomponents/webcomponentsjs": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/Rise-Vision/rise-data-financial#readme",
   "dependencies": {
     "@polymer/iron-jsonp-library": "^3.0.1",
-    "@polymer/polymer": "^3.0.5",
+    "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
     "common-component": "git://github.com/Rise-Vision/common-component.git#v1.16.1"
   },


### PR DESCRIPTION
- The latest release of [polymer-cli](https://github.com/Polymer/tools/blob/master/packages/cli/CHANGELOG.md) `1.9.8` has updated the dependency on polymer-build which it  has now disabled the babel minify built-in plugins, see [here](https://github.com/Polymer/tools/blob/master/packages/build/CHANGELOG.md#313---2019-04-02). Reasons state that there were errors with `babel-preset-minify` when used for latest Polymer `3.2.0` code, see more detail [here](https://github.com/Polymer/tools/pull/3388). I have raised an issue to inquire if there are plans to turn back on, see https://github.com/Polymer/tools/issues/3401 
- Moving forward for now, we should fix Polymer to version `3.1.0` and ensure the global `polymer-cli` version installed is fixed to `1.9.7`. 

@andrecardoso @tejohnso FYI