### PR TITLE
Add property to 'data-update' indicating if the event was caused by user changes or timed refresh

### DIFF
--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -111,6 +111,7 @@ class RiseDataFinancial extends PolymerElement {
     this._initialStart = true;
     this._logDataUpdate = true;
     this._financialRequestRetryCount = 0;
+    this._userConfigChange = false;
   }
 
   ready() {
@@ -177,6 +178,7 @@ class RiseDataFinancial extends PolymerElement {
   _reset() {
     if ( !this._initialStart ) {
       this._logDataUpdate = true;
+      this._userConfigChange = true;
       this._refreshDebounceJob && this._refreshDebounceJob.cancel();
 
       this._log( "info", "reset", {
@@ -268,7 +270,11 @@ class RiseDataFinancial extends PolymerElement {
       this._log( "error", RiseDataFinancial.EVENT_DATA_ERROR, { error: detail.errors[ 0 ] });
       this._sendFinancialEvent( RiseDataFinancial.EVENT_DATA_ERROR, detail.errors[ 0 ]);
     } else {
-      let data = {};
+      let data = {
+        "user-config-change": this._userConfigChange
+      };
+
+      this._userConfigChange = false;
 
       if ( detail.hasOwnProperty( "table" ) && detail.table ) {
         data.data = detail.table;

--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -137,6 +137,7 @@
       assert.equal( RisePlayerConfiguration.Logger.info.args[ 0 ][ 1 ], "data-update");
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], {
         data: realTimeData.table,
+        "user-config-change": false
       } );
 
       RisePlayerConfiguration.Logger.info.resetHistory();

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -340,6 +340,7 @@
         const listener = ( evt ) => {
           assert.deepEqual( evt.detail, {
             data: realTimeData.table,
+            "user-config-change": false
           } );
 
           element.removeEventListener( "data-update", listener );
@@ -352,7 +353,7 @@
 
       test( "should send 'data-update' event with empty detail when no table provided", ( done ) => {
         const listener = ( evt ) => {
-          assert.deepEqual( evt.detail, {} );
+          assert.deepEqual( evt.detail, { "user-config-change": false } );
 
           element.removeEventListener( "data-update", listener );
           done();

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -456,6 +456,7 @@
 
         assert.isTrue( element._logDataUpdate );
         assert.isTrue( getDataStub.calledOnce );
+        assert.isTrue( element._logDataUpdate );
 
         _resetStub = sinon.stub( element, "_reset" );
       } );

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -456,7 +456,7 @@
 
         assert.isTrue( element._logDataUpdate );
         assert.isTrue( getDataStub.calledOnce );
-        assert.isTrue( element._logDataUpdate );
+        assert.isTrue( element._userConfigChange );
 
         _resetStub = sinon.stub( element, "_reset" );
       } );


### PR DESCRIPTION
This handles https://trello.com/c/GSbbxedq/6852-add-supportive-events-for-rise-data-financial-2

@santiagonoguez @stulees please review
