### PR TITLE
log at most once per day data and reset events

### DIFF
--- a/demo/src/rise-data-financial.html
+++ b/demo/src/rise-data-financial.html
@@ -53,11 +53,11 @@
       } );
 
       financial01.addEventListener( "data-error", ( evt ) => {
-        console.log( "data error", evt.detail );
+        console.log( "data error", JSON.stringify(evt.detail) );
       } );
 
       financial01.addEventListener( "request-error", ( evt ) => {
-        console.log( "request error", evt.detail );
+        console.log( "request error", JSON.stringify(evt.detail) );
       } );
 
       // Uncomment the following line if the financial component is marked as non-editable

--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -139,12 +139,9 @@
         data: realTimeData.table,
         "user-config-change": false
       } );
-
-      RisePlayerConfiguration.Logger.info.resetHistory();
-      element._handleData( { detail: [ realTimeData ] } );
-
-      // should only log data-update event once
-      assert.isFalse( RisePlayerConfiguration.Logger.info.called );
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
+        _logAtMostOncePerDay: true
+      } );
 
     } );
 

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -451,10 +451,8 @@
         // need to remove the stub and add back on every test
         _resetStub.restore();
         element._initialStart = false;
-        element._logDataUpdate = false;
         element._reset();
 
-        assert.isTrue( element._logDataUpdate );
         assert.isTrue( getDataStub.calledOnce );
         assert.isTrue( element._userConfigChange );
 


### PR DESCRIPTION
Instead of logging every data and reset event, we are now limiting them to once per day.

This was tested here:
https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_4deb4336_16b8a2679bf
