### PR TITLE
send 'rise is not permissioned' as warning

### DIFF
--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -90,9 +90,18 @@ class RiseDataFinancial extends RiseElement {
 
   static get ERROR_EVENTS() {
     return {
-      "N/P": "Rise is not permissioned to show the instrument",
-      "N/A": "Instrument is unavailable, invalid or unknown",
-      "S/P": "Display is not permissioned to show the instrument"
+      "N/P": {
+        message: "Rise is not permissioned to show the instrument",
+        level: "warning"
+      },
+      "N/A": {
+        message: "Instrument is unavailable, invalid or unknown",
+        level: "error"
+      },
+      "S/P": {
+        message: "Display is not permissioned to show the instrument",
+        level: "error"
+      }
     };
   }
 
@@ -268,9 +277,9 @@ class RiseDataFinancial extends RiseElement {
         if ( data.data && data.data.rows && data.data.rows.some( row =>
           row.c && row.c.some( cell => cell.v === status )
         )) {
-          const errorMessage = RiseDataFinancial.ERROR_EVENTS[ status ];
+          const error = RiseDataFinancial.ERROR_EVENTS[ status ];
 
-          this._log( "error", `${ errorMessage }`, {
+          this._log( error.level, `${ error.message }`, {
             symbols: this.symbols
           }, RiseDataFinancial.LOG_AT_MOST_ONCE_PER_DAY );
         }

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -527,7 +527,7 @@
         stub.restore();
       } );
 
-      test( "should log N/P error if it's present in the data", () => {
+      test( "should log N/P warning if it's present in the data", () => {
         const stub = sinon.stub( element, "_log" );
 
         sampleData.data.rows[0].c[0].v = "N/P";
@@ -535,7 +535,7 @@
         element._checkFinancialErrors( sampleData );
 
         assert.isTrue( stub.calledWith(
-          "error",
+          "warning",
           "Rise is not permissioned to show the instrument",
           { symbols: element.symbols }
         ));
@@ -552,13 +552,29 @@
         element._checkFinancialErrors( sampleData );
 
         assert.isTrue( stub.calledWith(
-          "error",
+          "warning",
           "Rise is not permissioned to show the instrument",
           { symbols: element.symbols }
         ));
         assert.isTrue( stub.calledWith(
           "error",
           "Display is not permissioned to show the instrument",
+          { symbols: element.symbols }
+        ));
+
+        stub.restore();
+      } );
+
+      test( "should log N/A error if it's present in the data", () => {
+        const stub = sinon.stub( element, "_log" );
+
+        sampleData.data.rows[0].c[0].v = "N/A";
+
+        element._checkFinancialErrors( sampleData );
+
+        assert.isTrue( stub.calledWith(
+          "error",
+          "Instrument is unavailable, invalid or unknown",
           { symbols: element.symbols }
         ));
 


### PR DESCRIPTION
Changes N/P occurrences to warning.

This won't be merged until Monday, so we may still have 'not permissioned' errors on the weekend and Monday morning.

@sheadarlison 
