### PR TITLE
Additional logging to provide insight for rejected response.text()

### DIFF
--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -414,7 +414,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
         this._handleParseError( "error parsing text", err );
       }
     })
-      .catch( err => this._handleParseError( "error parsing response", err, resp ));
+      .catch( err => this._handleParseError( "error parsing response from valid cache", err, resp ));
   }
 
   _processInvalidCacheResponse( resp ) {
@@ -428,7 +428,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
           this._handleParseError( "error parsing text", err );
         }
       })
-        .catch( err => this._handleParseError( "error parsing response", err, resp ));
+        .catch( err => this._handleParseError( "error parsing response from expired/invalid cache", err, resp ));
     } else {
       this._requestData( null );
     }

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -82,6 +82,9 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   static get EVENT_DATA_UPDATE() {
     return "data-update";
   }
+  static get EVENT_DATA_CACHE() {
+    return "data-cache";
+  }
   static get EVENT_DATA_ERROR() {
     return "data-error";
   }
@@ -301,6 +304,9 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
           }
         };
 
+        // Just log these entries once per day, as they may consume lots of log space.
+        this._log( "info", RiseDataFinancial.EVENT_DATA_CACHE, { key: this._cacheKey, event }, RiseDataFinancial.LOG_AT_MOST_ONCE_PER_DAY );
+
         super.putCache && super.putCache( new Response( JSON.stringify( event ), options ), this._cacheKey );
       }
     }
@@ -394,8 +400,8 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
     return value;
   }
 
-  _handleParseError( event, err ) {
-    this._log( "error", event, { err }, RiseDataFinancial.LOG_AT_MOST_ONCE_PER_DAY );
+  _handleParseError( event, err, resp ) {
+    this._log( "error", event, { err, resp }, RiseDataFinancial.LOG_AT_MOST_ONCE_PER_DAY );
   }
 
   _processValidCacheResponse( resp ) {
@@ -408,7 +414,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
         this._handleParseError( "error parsing text", err );
       }
     })
-      .catch( err => this._handleParseError( "error parsing response", err ));
+      .catch( err => this._handleParseError( "error parsing response", err, resp ));
   }
 
   _processInvalidCacheResponse( resp ) {
@@ -422,7 +428,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
           this._handleParseError( "error parsing text", err );
         }
       })
-        .catch( err => this._handleParseError( "error parsing response", err ));
+        .catch( err => this._handleParseError( "error parsing response", err, resp ));
     } else {
       this._requestData( null );
     }

--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -139,7 +139,8 @@
       element._refresh.restore();
     } );
 
-    test( "should log 'data-update' info event", () => {
+    test( "should log 'data-update' and 'data-cache' info event", () => {
+      element._cacheKey = element._getCacheKey();
       element._handleData( { detail: [ realTimeData ] } );
 
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 0 ], componentData );
@@ -150,6 +151,16 @@
         "user-config-change": false
       } );
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
+        _logAtMostOncePerDay: true
+      } );
+
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
+      assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "data-cache");
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], {
+        key: "risedatafinancial_realtime_preview_AA.N|.DJI_1M_lastPrice,netChange",
+        event: { detail: [ realTimeData ] }
+      } );
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
         _logAtMostOncePerDay: true
       } );
 


### PR DESCRIPTION
## Description
Provide extra logging info for putting data to cache and when `response.text()` is rejected

## Motivation and Context
In monitoring/validating _Bonds_ template running v3 of the component, 2 out of 26 displays running the template have reported a _"error parsing response"_ error event, which can only happen when `response.text()` is rejected. It is unclear why this would happen, and the `err` param from the `catch()` is empty. The displays are still running without issue, but they have large schedules and I've not been able to see if the specific chart is impacted from the specific financial component instances that reported the error. 

https://bigquery.cloud.google.com/results/client-side-events:US.bquijob_3859576e_16d020f47d0?pli=1

## How Has This Been Tested?
Only tested through test coverage as this is just additional log info. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Automated test added
  - Will validate on production with the displays currently running _bonds_ or _tsx-gainers-losers_ templates
  - Rollback will involve rerunning previous master build on CCI
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Support don't need to be notified, documentation not required
