### PR TITLE
Revert back to version 2 to deploy caching/offline feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,21 @@ The component may log the following errors:
 - **_Rise is not permissioned to show the instrument_**: Shown when financial server returned a 'N/P' status for an instrument / symbol. The event details will include the component symbols property.
 - **_Instrument is unavailable, invalid or unknown_**: Shown when financial server returned a 'N/A' status for an instrument / symbol. The event details will include the component symbols property.
 - **_Display is not permissioned to show the instrument_**: Shown when financial server returned a 'S/P' status for an instrument / symbol. The event details will include the component symbols property.
+- **_error parsing response from valid cache_**: There was a Promise rejection when calling `text()` method of valid cached `Response` object.
+- **_error parsing response from expired/invalid cache_**: There was a Promise rejection when calling `text()` method of expired cached `Response` object.
+- **_error parsing text_**: There was a problem when JSON parsing the valid or expired cached _event_ object
 
 In every case, examine event-details entry and the other event fields for more information about the problem.
+
+### Offline play
+
+The component supports offline play by relying on the browsers Cache API availability.
+
+Every time a successful request is made to the Financial server via the `<iron-jsonp-library>` component, the _event_ object that is returned from the `<iron-jsonp-library>` response trigger/handler is stored locally in the cache. In case connectivity is lost, the latest cached version will be available. Upon a Player restart, if a cached version exists it will be used until connectivity is restored.
+
+When running online and components `type` is configured for _realtime_, the duration that a cached response is valid for is 55 seconds which allows for a fresh request to the Financial server every minute to obtain realtime data. 
+
+When running online and components `type` is configured for _historical_, the duration that a cached response is valid for is 24 hours which means only one fresh request to Financial Server is made per day for _historical_ data. This rule is applicable to all `duration` configurations (i.e. _Week_, _Month_, _Year_, etc) except for _Day_. When configured for _Day_ duration, the same rules of _realtime_ are applied (55 second cache expiry)
 
 ## Built With
 - [Polymer 3](https://www.polymer-project.org/)

--- a/demo/src/rise-data-financial.html
+++ b/demo/src/rise-data-financial.html
@@ -20,7 +20,7 @@
   </script>
   <script src="https://widgets.risevision.com/beta/common/config-test.min.js"></script>
   <script src="https://widgets.risevision.com/beta/common/common-template.min.js"></script>
-  <script src="https://widgets.risevision.com/beta/components/rise-data-financial/1/rise-data-financial.js"></script>
+  <script src="https://widgets.risevision.com/beta/components/rise-data-financial/2/rise-data-financial.js"></script>
   <script>
     if (document.domain.indexOf("localhost") === -1) {
       try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
     "build": "./create_config.sh prod && polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-financial",


### PR DESCRIPTION
## Description
Revert version to `2.1.0` from `3.0.0` to officially release caching/offline feature to all financial templates running version `2` of the component. 

## Motivation and Context
The component needs to cache data for offline purposes and to reduce the amount of requests made to Financial Server as Google monthly costs have risen substantially as of late. 

Both _bonds_ and _tsx-gainers-losers_ templates have recently been updated to run the temporary v3 of the component to test/validate the caching/offline feature. 

A total of 28 user displays have been running one or both those templates without issue since their deployment. There were 2 displays that had a couple component instances report a cache response parsing problem and it is not clear as to why this occurred, so further logging was added to aid in trying to understand why. In all these cases,  the displays continued to show their content and cycle through their schedule as normal.  These 2 displays have since been rebooted after the additional logging was added and have not reported the error again. 

## How Has This Been Tested?
Locally tested via ChrOS player and Windows, via Charles. Also monitored logs and screenshots of other Rise Vision displays and the 28 user displays running _bonds_ and _tsx-gainers-losers_ templates.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
  - Testing already implemented in previous PR (v3)
  - Will validate my own displays on production after deployment. I will also be rebooting 5 random user displays that are running financial templates using v2 and check logs and screenshots. In morning the same process will be done.
  - Rollback will involve re-running last CCI master build of v2. Then all displays running templates that have been updated to use v2 will require rebooting (this is only if deemed necessary). 
  - Support will be notified that we've released updated changes to financial component and they should notify us immediately of any tickets that seem related to Financial templates.
  - Documentation has been added to README
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
