### PR TITLE
Account for empty cached response object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
     "build": "./create_config.sh prod && polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-financial",

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -417,7 +417,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
       })
         .catch( err => this._handleParseError( "error parsing response from valid cache", err, resp ));
     } else {
-      this._log( "warning", "empty valid cache response object", { key: this._cacheKey } );
+      this._log( "warning", "empty valid cache response object", { key: this._cacheKey });
       // ensure a request for the data occurs
       this._processInvalidCacheResponse();
     }
@@ -438,7 +438,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
         .catch( err => this._handleParseError( "error parsing response from expired/invalid cache", err, resp ));
     } else {
       if ( resp && !resp.text ) {
-        this._log( "warning", "empty expired cache response object", { key: this._cacheKey } );
+        this._log( "warning", "empty expired cache response object", { key: this._cacheKey });
       }
 
       this._requestData( null );

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -405,20 +405,27 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   }
 
   _processValidCacheResponse( resp ) {
-    resp.text().then( event => {
-      try {
-        const parsed = JSON.parse( event, this._dateReviver );
+    if ( resp && resp.text ) {
+      resp.text().then( event => {
+        try {
+          const parsed = JSON.parse( event, this._dateReviver );
 
-        this._handleData( Object.assign( parsed, { cached: true }));
-      } catch ( err ) {
-        this._handleParseError( "error parsing text", err );
-      }
-    })
-      .catch( err => this._handleParseError( "error parsing response from valid cache", err, resp ));
+          this._handleData( Object.assign( parsed, { cached: true }));
+        } catch ( err ) {
+          this._handleParseError( "error parsing text", err );
+        }
+      })
+        .catch( err => this._handleParseError( "error parsing response from valid cache", err, resp ));
+    } else {
+      this._log( "warning", "empty valid cache response object", { key: this._cacheKey } );
+      // ensure a request for the data occurs
+      this._processInvalidCacheResponse();
+    }
+
   }
 
   _processInvalidCacheResponse( resp ) {
-    if ( resp ) {
+    if ( resp && resp.text ) {
       resp.text().then( event => {
         try {
           const parsed = JSON.parse( event, this._dateReviver );
@@ -430,6 +437,10 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
       })
         .catch( err => this._handleParseError( "error parsing response from expired/invalid cache", err, resp ));
     } else {
+      if ( resp && !resp.text ) {
+        this._log( "warning", "empty expired cache response object", { key: this._cacheKey } );
+      }
+
       this._requestData( null );
     }
   }

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -387,46 +387,50 @@
         assert.include( element._getSerializedUrl.args[0][1].tqx, "out:json;responseHandler:" );
       } );
 
-      test( "should call _handleData from a valid cache response with correct params", (done) => {
-        sandbox.stub(cacheMixin, "getCache").resolves(new Response(JSON.stringify({ detail: [ realTimeData ] })));
-        sinon.stub(element, "_handleData");
+      test( "should call _processValidCacheResponse from a valid cache response", (done) => {
+        const resp = new Response(JSON.stringify({ detail: [ realTimeData ] }));
+
+        sandbox.stub(cacheMixin, "getCache").resolves(resp);
+        sinon.stub(element, "_processValidCacheResponse");
         clock.restore();
 
         element._getData( element.symbols, props, fields );
 
         setTimeout(()=>{
-          assert.isTrue(element._handleData.calledWith({ detail: [ realTimeData ], cached:true }));
+          assert.isTrue(element._processValidCacheResponse.calledWith(resp));
           clock = sinon.useFakeTimers();
           done();
         }, 200);
 
       });
 
-      test( "should call _requestData from an expired cache response with correct params", (done) => {
-        sandbox.stub(cacheMixin, "getCache").callsFake(() => Promise.reject(new Response(JSON.stringify({ detail: [ realTimeData ] }))));
-        sinon.stub(element, "_requestData");
+      test( "should call _processInvalidCacheResponse from an expired cache response", (done) => {
+        const resp = new Response(JSON.stringify({ detail: [ realTimeData ] }));
+
+        sandbox.stub(cacheMixin, "getCache").callsFake(() => Promise.reject(resp));
+        sinon.stub(element, "_processInvalidCacheResponse");
         clock.restore();
 
         element._getData( element.symbols, props, fields );
 
         setTimeout(()=>{
-          assert.isTrue(element._requestData.calledWith({ detail: [ realTimeData ], cached:true }));
+          assert.isTrue(element._processInvalidCacheResponse.calledWith(resp));
           clock = sinon.useFakeTimers();
           done();
         }, 200);
 
       });
 
-      test( "should call _requestData when no cache response with correct params", (done) => {
+      test( "should call _processInvalidCacheResponse when no cache response", (done) => {
         sandbox.stub(cacheMixin, "getCache").callsFake(()=> Promise.reject());
 
-        sinon.stub(element, "_requestData");
+        sinon.stub(element, "_processInvalidCacheResponse");
         clock.restore();
 
         element._getData( element.symbols, props, fields );
 
         setTimeout(()=>{
-          assert.isTrue(element._requestData.calledWith(null));
+          assert.isTrue(element._processInvalidCacheResponse.calledWith(undefined));
           clock = sinon.useFakeTimers();
           done();
         }, 200);
@@ -501,6 +505,61 @@
         assert.isFalse( cacheMixin.putCache.called);
       } );
 
+    } );
+
+    suite( "_processValidCacheResponse", () => {
+
+      setup( () => {
+        sinon.stub( element, "_handleData" );
+        sinon.stub( element, "_processInvalidCacheResponse" );
+      } );
+
+      test( "should call _handleData() with correct params from processing response", (done) => {
+        clock.restore();
+
+        element._processValidCacheResponse( new Response(JSON.stringify({ detail: [ realTimeData ] })) );
+
+        setTimeout(()=>{
+          assert.isTrue(element._handleData.calledWith({ detail: [ realTimeData ], cached:true }));
+          clock = sinon.useFakeTimers();
+          done();
+        }, 200);
+
+      } );
+
+      test( "should call _processInvalidCacheResponse() when response object is empty", () => {
+        element._processValidCacheResponse( {} );
+        assert.isTrue( element._processInvalidCacheResponse.called );
+      } );
+    } );
+
+    suite( "_processInvalidCacheResponse", () => {
+      setup( () => {
+        sinon.stub( element, "_requestData" );
+      } );
+
+      test( "should call _requestData() with correct params from processing response", (done) => {
+        clock.restore();
+
+        element._processInvalidCacheResponse( new Response(JSON.stringify({ detail: [ realTimeData ] })) );
+
+        setTimeout(()=>{
+          assert.isTrue(element._requestData.calledWith({ detail: [ realTimeData ], cached:true }));
+          clock = sinon.useFakeTimers();
+          done();
+        }, 200);
+
+      } );
+
+      test( "should call _requestData() when response object is empty", () => {
+        element._processInvalidCacheResponse( {} );
+        assert.isTrue( element._requestData.calledWith( null ) );
+      } );
+
+      test( "should call _requestData() when no response object provided", () => {
+        element._processInvalidCacheResponse();
+        assert.isTrue( element._requestData.calledWith( null ) );
+      } );
     } );
 
     suite( "_processError", () => {


### PR DESCRIPTION
## Description
Check existence of `text` property for cached response object to account for empty object value

## Motivation and Context
Logs have reported a small amount of instances on a low amount of displays report _error parsing response from valid cache_ and _error parsing response from invalid/expired cache_. The logs indicate the Response object being processed is an empty object, so the `text()` method doesn't exist. It is not clear why the object is empty, but these changes ensure that a request will be made for data when this occurs. 

## How Has This Been Tested?
Tested that component works as expected running on local ChrOS player via Charles

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested locally
  - Automated tests added
  - Will validate no issues with my displays once deployed to production
  - Rollback will involve re-running previous master and build/stable CCI builds
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No documentation needed, Support not required to be notified
