### PR TITLE
Fix log call to correctly include err object in event_details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "3.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1123,8 +1123,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#0aab85592c0ab84ccf73da59d04271576e7b3035",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.12",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#ba498789e1eebb28db525b7a569453c239a621c9",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.3",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "^2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@polymer/iron-jsonp-library": "^3.0.1",
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.0"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.3"
   },
   "devDependencies": {
     "eslint": "^5.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
     "build": "./create_config.sh prod && polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-financial",


### PR DESCRIPTION
## Description
Use latest rise-common-component

## Motivation and Context
Fix financial component when cache mixin logs warning for `cache put fail` - https://github.com/Rise-Vision/rise-common-component/pull/29

## How Has This Been Tested?
Tested manually on ChrOS player and Charles Proxy

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested
  - Will validate on production post deployment
  - Rollback involves rerunning previous stable CCI branch deployment
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Documentation, automated tests, notifying Support
