### PR TITLE
Change cache key value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1123,8 +1123,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#ba498789e1eebb28db525b7a569453c239a621c9",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.3",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#8ba02ff7c389708945320146c5b9c8eedbddbefa",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.2.0",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
     "build": "./create_config.sh prod && polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-financial",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
     "build": "./create_config.sh prod && polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-financial",

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -355,7 +355,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   _getCacheKey() {
     const fields = this.instrumentFields.length > 0 ? this.instrumentFields.join( "," ) : "";
 
-    return `cache_${this._getKey()}_${fields}`;
+    return `${this._getKey()}_${fields}`;
   }
 
   _getCallbackValue( key ) {
@@ -514,7 +514,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   _configureCache() {
     if ( this._isValidType( this.type )) {
       const initObj = {
-        name: this.tagName.toLowerCase(),
+        name: `${this.tagName.toLowerCase()}_${version}`,
         expiry: -1
       };
 

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -355,7 +355,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   _getCacheKey() {
     const fields = this.instrumentFields.length > 0 ? this.instrumentFields.join( "," ) : "";
 
-    return `${this._getKey()}_${fields}`;
+    return `cache_${this._getKey()}_${fields}`;
   }
 
   _getCallbackValue( key ) {

--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -157,7 +157,7 @@
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
       assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "data-cache");
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], {
-        key: "cache_risedatafinancial_realtime_preview_AA.N|.DJI_1M_lastPrice,netChange",
+        key: "risedatafinancial_realtime_preview_AA.N|.DJI_1M_lastPrice,netChange",
         event: { detail: [ realTimeData ] }
       } );
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {

--- a/test/integration/rise-data-financial-logging.html
+++ b/test/integration/rise-data-financial-logging.html
@@ -157,7 +157,7 @@
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
       assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "data-cache");
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], {
-        key: "risedatafinancial_realtime_preview_AA.N|.DJI_1M_lastPrice,netChange",
+        key: "cache_risedatafinancial_realtime_preview_AA.N|.DJI_1M_lastPrice,netChange",
         event: { detail: [ realTimeData ] }
       } );
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -828,7 +828,7 @@
 
         assert.isTrue(cacheMixin.initCache.called);
         assert.isTrue(cacheMixin.initCache.calledWith({
-          name: "rise-data-financial",
+          name: "rise-data-financial___VERSION__",
           refresh: 55000,
           expiry: -1
         }));
@@ -843,7 +843,7 @@
 
         assert.isTrue( cacheMixin.initCache.called );
         assert.isTrue( cacheMixin.initCache.calledWith({
-          name: "rise-data-financial",
+          name: "rise-data-financial___VERSION__",
           refresh: 55000,
           expiry: -1
         }) );
@@ -856,7 +856,7 @@
 
         assert.isTrue( cacheMixin.initCache.called );
         assert.isTrue( cacheMixin.initCache.calledWith({
-          name: "rise-data-financial",
+          name: "rise-data-financial___VERSION__",
           refresh: 86400000,
           expiry: -1
         }) );

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -233,7 +233,7 @@
     suite( "_getCacheKey()", () => {
 
       test( "should return correct key value when configured with defaults", () => {
-        const expected = `risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_lastPrice,netChange`;
+        const expected = `cache_risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_lastPrice,netChange`;
         assert.equal( element._getCacheKey(), expected );
       } );
 
@@ -243,7 +243,7 @@
         element.duration = "week";
         element.instrumentFields = ["name", "percentChange"];
 
-        const expected = `risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_name,percentChange`;
+        const expected = `cache_risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_name,percentChange`;
         assert.equal( element._getCacheKey(), expected );
       } );
 

--- a/test/unit/rise-data-financial.html
+++ b/test/unit/rise-data-financial.html
@@ -233,7 +233,7 @@
     suite( "_getCacheKey()", () => {
 
       test( "should return correct key value when configured with defaults", () => {
-        const expected = `cache_risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_lastPrice,netChange`;
+        const expected = `risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_lastPrice,netChange`;
         assert.equal( element._getCacheKey(), expected );
       } );
 
@@ -243,7 +243,7 @@
         element.duration = "week";
         element.instrumentFields = ["name", "percentChange"];
 
-        const expected = `cache_risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_name,percentChange`;
+        const expected = `risedatafinancial_${element.type}_${element.displayId}_${element.symbols}_${element.duration}_name,percentChange`;
         assert.equal( element._getCacheKey(), expected );
       } );
 


### PR DESCRIPTION
## Description
Change the construction of the cache key value to append `version`

## Motivation and Context
To resolve the displays that encountered a Player upgrade and then degrade and are now failing to cache because of the reversion to Chrome 56 from 69. This reversion has caused a problem with current state of financial cache in Cache API. Using a new cache key will ensure all instances start a new cache entry and should correct these displays that encountered a problem. 

## How Has This Been Tested?
Automated tests updated.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Will validate by rebooting a couple displays that have had problems caching. 
  - Rollback will involve rerunning previous build/stable CCI deployment and reboot those couple displays again
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Documentation, automated tests, notifying Support
