### PR TITLE
Ensure to clone response before processing it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-financial",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Web component for retrieving financial data on a Rise Vision Template page",
   "scripts": {
     "build": "./create_config.sh prod && polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-financial",

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -517,8 +517,8 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
     this._cacheKey = this._getCacheKey();
 
     return this._tryGetCache( this._cacheKey )
-      .then( resp => this._processValidCacheResponse( resp ))
-      .catch(( cachedResp ) => this._processInvalidCacheResponse( cachedResp ));
+      .then( resp => this._processValidCacheResponse( resp.clone() ))
+      .catch(( cachedResp ) => this._processInvalidCacheResponse( cachedResp.clone() ));
   }
 
   _refresh( interval ) {

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -517,8 +517,8 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
     this._cacheKey = this._getCacheKey();
 
     return this._tryGetCache( this._cacheKey )
-      .then( resp => this._processValidCacheResponse( resp.clone() ))
-      .catch(( cachedResp ) => this._processInvalidCacheResponse( cachedResp.clone() ));
+      .then( resp => this._processValidCacheResponse( resp.clone()))
+      .catch(( cachedResp ) => this._processInvalidCacheResponse( cachedResp.clone()));
   }
 
   _refresh( interval ) {

--- a/src/rise-data-financial.js
+++ b/src/rise-data-financial.js
@@ -433,7 +433,9 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   }
 
   _processValidCacheResponse( resp ) {
-    if ( resp && resp.text ) {
+    if ( resp && resp.clone ) {
+      resp = resp.clone();
+
       resp.text().then( event => {
         try {
           const parsed = JSON.parse( event, this._dateReviver );
@@ -453,7 +455,9 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
   }
 
   _processInvalidCacheResponse( resp ) {
-    if ( resp && resp.text ) {
+    if ( resp && resp.clone ) {
+      resp = resp.clone();
+
       resp.text().then( event => {
         try {
           const parsed = JSON.parse( event, this._dateReviver );
@@ -465,7 +469,7 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
       })
         .catch( err => this._handleParseError( "error parsing response from expired/invalid cache", err, resp ));
     } else {
-      if ( resp && !resp.text ) {
+      if ( resp && !resp.clone ) {
         this._log( "warning", "empty expired cache response object", { key: this._cacheKey });
       }
 
@@ -517,8 +521,8 @@ class RiseDataFinancial extends CacheMixin( RiseElement ) {
     this._cacheKey = this._getCacheKey();
 
     return this._tryGetCache( this._cacheKey )
-      .then( resp => this._processValidCacheResponse( resp.clone()))
-      .catch(( cachedResp ) => this._processInvalidCacheResponse( cachedResp.clone()));
+      .then( resp => this._processValidCacheResponse( resp ))
+      .catch(( cachedResp ) => this._processInvalidCacheResponse( cachedResp ));
   }
 
   _refresh( interval ) {


### PR DESCRIPTION
## Description
Call `clone()` on the cached response provided back from Cache API 

## Motivation and Context
The response body that the Cache API provides is a ReadableStream which gets locked to one reader at a time. Since the cache response being processed is not a clone/copy, it is vulnerable to multiple readers attempting to read at same time and cause an issue given the stream gets locked to one reader. 

This is the assumption of what is happening with issue #69 for the Ubuntu players. By ensuring to process a cloned version, there should be no issue with parsing the response via `text()`. 

## How Has This Been Tested?
I have not been able to recreate the issue to be able to validate the fix. I've just tested the component locally to just validate it continues to work as expected. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Will validate in production that this introduces no issues post deployment
  - Rollback will involve re-running last `build/stable` CCI deployment followed by reverting code base
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Documentation, notifying Support, automated tests
